### PR TITLE
Turn off doclint support during JavaDoc builds.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -462,6 +462,9 @@
 							<goals>
 								<goal>jar</goal>
 							</goals>
+							<configuration>
+								<additionalparam>-Xdoclint:none</additionalparam>
+							</configuration>
 						</execution>
 					</executions>
 				</plugin>


### PR DESCRIPTION
In Java8 doclint is enabled by default. The existing JavaDocs
do not properly compile with this setting, and the build fails
on Java8. This fixes the problem by turning doclink off
in the top level POM.xml

For more information see [1,2]

[1] http://mail.openjdk.java.net/pipermail/build-infra-dev/2013-January/002899.html
[2] http://stackoverflow.com/questions/15886209/maven-is-not-working-in-java-8-when-javadoc-tags-are-incomplete
