### PR TITLE
Turn off doclint support during JavaDoc builds.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -214,6 +214,25 @@
 			</repositories>
 		</profile>
 
+		<!-- SPECIAL PROFILE FOR JAVA 8-->
+		<profile>
+			<id>doclint-java8-disable</id>
+			<activation>
+				<jdk>[1.8,</jdk>
+			</activation>
+			<build>
+				<plugins>
+					<plugin>
+						<groupId>org.apache.maven.plugins</groupId>
+						<artifactId>maven-javadoc-plugin</artifactId>
+						<configuration>
+							<additionalparam>-Xdoclint:none</additionalparam>
+						</configuration>
+					</plugin>
+				</plugins>
+			</build>
+		</profile>
+
 	</profiles>
 
 	<!-- BUILD INSTRUCTIONS -->


### PR DESCRIPTION
In Java8 doclint is enabled by default. The existing JavaDocs
do not properly compile with this setting, and the build fails
on Java8. This fixes the problem by turning doclink off
in the top level POM.xml

A maven profile was used so this still builds on older JDKs
that don't understand this flag.

For more information see [1,2]

[1] http://mail.openjdk.java.net/pipermail/build-infra-dev/2013-January/002899.html
[2] http://stackoverflow.com/questions/15886209/maven-is-not-working-in-java-8-when-javadoc-tags-are-incomplete
