### PR TITLE
Added package com.pi4j.temperature to the set exported in the bundle manifest

### DIFF
--- a/pi4j-core/pom.xml
+++ b/pi4j-core/pom.xml
@@ -159,6 +159,7 @@
 							com.pi4j.jni.*,
 							com.pi4j.wiringpi.*,
 							com.pi4j.system.*,
+							com.pi4j.temperature.*,
 							com.pi4j.io.serial.*,
 							com.pi4j.io.gpio.*,
 							com.pi4j.io.i2c.*


### PR DESCRIPTION
I am using pi4j throught a osgi framework. Unfortunately, the package com.pi4j.temperature doesn't get exported. Could it be possible to add it ?
