### PR TITLE
 #85 reimplementing NativeLibraryLoader

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,9 @@ maven-eclipse.xml
 .externalToolBuilders
 /target
 /.settings
+.metadata/
+RemoteSystemsTempFiles/
+
 /pi4j-core/.settings
 /pi4j-core/.classpath
 /pi4j-example/.settings

--- a/pi4j-core/src/main/java/com/pi4j/concurrent/DefaultExecutorServiceFactory.java
+++ b/pi4j-core/src/main/java/com/pi4j/concurrent/DefaultExecutorServiceFactory.java
@@ -11,7 +11,7 @@ package com.pi4j.concurrent;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/concurrent/ExecutorServiceFactory.java
+++ b/pi4j-core/src/main/java/com/pi4j/concurrent/ExecutorServiceFactory.java
@@ -11,7 +11,7 @@ package com.pi4j.concurrent;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/concurrent/ScheduledExecutorServiceWrapper.java
+++ b/pi4j-core/src/main/java/com/pi4j/concurrent/ScheduledExecutorServiceWrapper.java
@@ -11,7 +11,7 @@ package com.pi4j.concurrent;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/GpioController.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/GpioController.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/GpioFactory.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/GpioFactory.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/GpioPin.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/GpioPin.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/GpioPinAnalog.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/GpioPinAnalog.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/GpioPinAnalogInput.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/GpioPinAnalogInput.java
@@ -17,7 +17,7 @@ import com.pi4j.io.gpio.trigger.GpioTrigger;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/GpioPinAnalogOutput.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/GpioPinAnalogOutput.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/GpioPinDigital.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/GpioPinDigital.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/GpioPinDigitalInput.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/GpioPinDigitalInput.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/GpioPinDigitalMultipurpose.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/GpioPinDigitalMultipurpose.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/GpioPinDigitalOutput.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/GpioPinDigitalOutput.java
@@ -13,7 +13,7 @@ import java.util.concurrent.Future;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/GpioPinInput.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/GpioPinInput.java
@@ -17,7 +17,7 @@ import com.pi4j.io.gpio.trigger.GpioTrigger;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/GpioPinOutput.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/GpioPinOutput.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/GpioPinPwm.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/GpioPinPwm.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/GpioPinPwmOutput.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/GpioPinPwmOutput.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/GpioPinShutdown.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/GpioPinShutdown.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/GpioProvider.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/GpioProvider.java
@@ -13,7 +13,7 @@ import com.pi4j.io.gpio.event.PinListener;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/GpioProviderBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/GpioProviderBase.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/GpioProviderPinCache.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/GpioProviderPinCache.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/PiFacePin.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/PiFacePin.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/Pin.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/Pin.java
@@ -13,7 +13,7 @@ import java.util.EnumSet;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/PinDirection.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/PinDirection.java
@@ -13,7 +13,7 @@ import java.util.EnumSet;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/PinEdge.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/PinEdge.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/PinMode.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/PinMode.java
@@ -13,7 +13,7 @@ import java.util.EnumSet;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/PinPullResistance.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/PinPullResistance.java
@@ -13,7 +13,7 @@ import java.util.EnumSet;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/PinState.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/PinState.java
@@ -13,7 +13,7 @@ import java.util.EnumSet;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/RaspiGpioProvider.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/RaspiGpioProvider.java
@@ -15,7 +15,7 @@ import com.pi4j.wiringpi.GpioInterruptListener;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/RaspiPin.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/RaspiPin.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/event/GpioPinAnalogValueChangeEvent.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/event/GpioPinAnalogValueChangeEvent.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio.event;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/event/GpioPinDigitalStateChangeEvent.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/event/GpioPinDigitalStateChangeEvent.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio.event;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/event/GpioPinEvent.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/event/GpioPinEvent.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio.event;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/event/GpioPinListener.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/event/GpioPinListener.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio.event;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/event/GpioPinListenerAnalog.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/event/GpioPinListenerAnalog.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio.event;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/event/GpioPinListenerDigital.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/event/GpioPinListenerDigital.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio.event;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/event/PinAnalogValueChangeEvent.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/event/PinAnalogValueChangeEvent.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio.event;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/event/PinDigitalStateChangeEvent.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/event/PinDigitalStateChangeEvent.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio.event;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/event/PinEvent.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/event/PinEvent.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio.event;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/event/PinEventType.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/event/PinEventType.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio.event;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/event/PinListener.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/event/PinListener.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio.event;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/exception/GpioPinExistsException.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/exception/GpioPinExistsException.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio.exception;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/exception/GpioPinNotProvisionedException.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/exception/GpioPinNotProvisionedException.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio.exception;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/exception/InvalidPinException.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/exception/InvalidPinException.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio.exception;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/exception/InvalidPinModeException.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/exception/InvalidPinModeException.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio.exception;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/exception/PinProviderException.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/exception/PinProviderException.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio.exception;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/exception/UnsupportedPinModeException.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/exception/UnsupportedPinModeException.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio.exception;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/exception/UnsupportedPinPullResistanceException.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/exception/UnsupportedPinPullResistanceException.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio.exception;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/impl/GpioControllerImpl.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/impl/GpioControllerImpl.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio.impl;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License"); you
  * may not use this file except in compliance with the License. You may obtain a copy of the License

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/impl/GpioEventMonitorExecutorImpl.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/impl/GpioEventMonitorExecutorImpl.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio.impl;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License"); you
  * may not use this file except in compliance with the License. You may obtain a copy of the License

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/impl/GpioEventMonitorImpl.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/impl/GpioEventMonitorImpl.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio.impl;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License"); you
  * may not use this file except in compliance with the License. You may obtain a copy of the License

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/impl/GpioPinImpl.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/impl/GpioPinImpl.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio.impl;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License"); you
  * may not use this file except in compliance with the License. You may obtain a copy of the License

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/impl/GpioPinShutdownImpl.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/impl/GpioPinShutdownImpl.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio.impl;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/impl/GpioScheduledExecutorImpl.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/impl/GpioScheduledExecutorImpl.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio.impl;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/impl/PinImpl.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/impl/PinImpl.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio.impl;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/tasks/impl/GpioBlinkStopTaskImpl.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/tasks/impl/GpioBlinkStopTaskImpl.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio.tasks.impl;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/tasks/impl/GpioBlinkTaskImpl.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/tasks/impl/GpioBlinkTaskImpl.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio.tasks.impl;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/tasks/impl/GpioEventDispatchTaskImpl.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/tasks/impl/GpioEventDispatchTaskImpl.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio.tasks.impl;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/tasks/impl/GpioPulseTaskImpl.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/tasks/impl/GpioPulseTaskImpl.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio.tasks.impl;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/trigger/GpioBlinkStateTrigger.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/trigger/GpioBlinkStateTrigger.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio.trigger;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/trigger/GpioBlinkStopStateTrigger.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/trigger/GpioBlinkStopStateTrigger.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio.trigger;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/trigger/GpioCallbackTrigger.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/trigger/GpioCallbackTrigger.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio.trigger;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/trigger/GpioInverseSyncStateTrigger.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/trigger/GpioInverseSyncStateTrigger.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio.trigger;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/trigger/GpioPulseStateTrigger.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/trigger/GpioPulseStateTrigger.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio.trigger;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/trigger/GpioSetStateTrigger.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/trigger/GpioSetStateTrigger.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio.trigger;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/trigger/GpioSyncStateTrigger.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/trigger/GpioSyncStateTrigger.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio.trigger;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/trigger/GpioToggleStateTrigger.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/trigger/GpioToggleStateTrigger.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio.trigger;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/trigger/GpioTrigger.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/trigger/GpioTrigger.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio.trigger;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/trigger/GpioTriggerBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/trigger/GpioTriggerBase.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio.trigger;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/i2c/I2CBus.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/i2c/I2CBus.java
@@ -11,7 +11,7 @@ package com.pi4j.io.i2c;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/i2c/I2CDevice.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/i2c/I2CDevice.java
@@ -11,7 +11,7 @@ package com.pi4j.io.i2c;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/i2c/I2CFactory.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/i2c/I2CFactory.java
@@ -11,7 +11,7 @@ package com.pi4j.io.i2c;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/i2c/impl/I2CBusImpl.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/i2c/impl/I2CBusImpl.java
@@ -11,7 +11,7 @@ package com.pi4j.io.i2c.impl;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/i2c/impl/I2CDeviceImpl.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/i2c/impl/I2CDeviceImpl.java
@@ -11,7 +11,7 @@ package com.pi4j.io.i2c.impl;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/serial/Serial.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/serial/Serial.java
@@ -11,7 +11,7 @@ package com.pi4j.io.serial;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/serial/SerialDataEvent.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/serial/SerialDataEvent.java
@@ -11,7 +11,7 @@ package com.pi4j.io.serial;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/serial/SerialDataListener.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/serial/SerialDataListener.java
@@ -11,7 +11,7 @@ package com.pi4j.io.serial;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/serial/SerialFactory.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/serial/SerialFactory.java
@@ -11,7 +11,7 @@ package com.pi4j.io.serial;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/serial/SerialPortException.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/serial/SerialPortException.java
@@ -11,7 +11,7 @@ package com.pi4j.io.serial;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/serial/impl/SerialDataMonitorThread.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/serial/impl/SerialDataMonitorThread.java
@@ -11,7 +11,7 @@ package com.pi4j.io.serial.impl;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/io/serial/impl/SerialImpl.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/serial/impl/SerialImpl.java
@@ -11,7 +11,7 @@ package com.pi4j.io.serial.impl;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/jni/I2C.java
+++ b/pi4j-core/src/main/java/com/pi4j/jni/I2C.java
@@ -11,7 +11,7 @@ package com.pi4j.jni;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -52,7 +52,7 @@ public class I2C {
     
     static {
         // Load the platform library
-        NativeLibraryLoader.load("pi4j", "libpi4j.so");
+        NativeLibraryLoader.load("libpi4j.so");
     }
 
     /**

--- a/pi4j-core/src/main/java/com/pi4j/jni/Serial.java
+++ b/pi4j-core/src/main/java/com/pi4j/jni/Serial.java
@@ -11,7 +11,7 @@ package com.pi4j.jni;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/system/NetworkInfo.java
+++ b/pi4j-core/src/main/java/com/pi4j/system/NetworkInfo.java
@@ -11,7 +11,7 @@ package com.pi4j.system;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/system/NetworkInterface.java
+++ b/pi4j-core/src/main/java/com/pi4j/system/NetworkInterface.java
@@ -11,7 +11,7 @@ package com.pi4j.system;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/system/SystemInfo.java
+++ b/pi4j-core/src/main/java/com/pi4j/system/SystemInfo.java
@@ -11,7 +11,7 @@ package com.pi4j.system;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/temperature/TemperatureConversion.java
+++ b/pi4j-core/src/main/java/com/pi4j/temperature/TemperatureConversion.java
@@ -11,7 +11,7 @@ package com.pi4j.temperature;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/temperature/TemperatureScale.java
+++ b/pi4j-core/src/main/java/com/pi4j/temperature/TemperatureScale.java
@@ -11,7 +11,7 @@ package com.pi4j.temperature;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/util/ExecUtil.java
+++ b/pi4j-core/src/main/java/com/pi4j/util/ExecUtil.java
@@ -11,7 +11,7 @@ package com.pi4j.util;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/util/StringUtil.java
+++ b/pi4j-core/src/main/java/com/pi4j/util/StringUtil.java
@@ -11,7 +11,7 @@ package com.pi4j.util;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/wiringpi/Gertboard.java
+++ b/pi4j-core/src/main/java/com/pi4j/wiringpi/Gertboard.java
@@ -11,7 +11,7 @@ package com.pi4j.wiringpi;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -88,7 +88,7 @@ public class Gertboard {
     
     static {
         // Load the platform library
-        NativeLibraryLoader.load("pi4j", "libpi4j.so");
+        NativeLibraryLoader.load("libpi4j.so");
     }
 
     /**

--- a/pi4j-core/src/main/java/com/pi4j/wiringpi/Gpio.java
+++ b/pi4j-core/src/main/java/com/pi4j/wiringpi/Gpio.java
@@ -11,7 +11,7 @@ package com.pi4j.wiringpi;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -135,7 +135,7 @@ public class Gpio {
 
     static {
         // Load the platform library
-        NativeLibraryLoader.load("pi4j", "libpi4j.so");
+        NativeLibraryLoader.load("libpi4j.so");
     }
 
     /**

--- a/pi4j-core/src/main/java/com/pi4j/wiringpi/GpioInterrupt.java
+++ b/pi4j-core/src/main/java/com/pi4j/wiringpi/GpioInterrupt.java
@@ -11,7 +11,7 @@ package com.pi4j.wiringpi;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -67,7 +67,7 @@ public class GpioInterrupt {
     
     static {
         // Load the platform library
-        NativeLibraryLoader.load("pi4j", "libpi4j.so");
+        NativeLibraryLoader.load("libpi4j.so");
     }
 
     /**

--- a/pi4j-core/src/main/java/com/pi4j/wiringpi/GpioInterruptEvent.java
+++ b/pi4j-core/src/main/java/com/pi4j/wiringpi/GpioInterruptEvent.java
@@ -11,7 +11,7 @@ package com.pi4j.wiringpi;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/wiringpi/GpioInterruptListener.java
+++ b/pi4j-core/src/main/java/com/pi4j/wiringpi/GpioInterruptListener.java
@@ -11,7 +11,7 @@ package com.pi4j.wiringpi;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/main/java/com/pi4j/wiringpi/GpioUtil.java
+++ b/pi4j-core/src/main/java/com/pi4j/wiringpi/GpioUtil.java
@@ -11,7 +11,7 @@ package com.pi4j.wiringpi;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,7 +59,7 @@ public class GpioUtil {
     
     static {
         // Load the platform library
-        NativeLibraryLoader.load("pi4j", "libpi4j.so");
+        NativeLibraryLoader.load("libpi4j.so");
     }
 
     /**

--- a/pi4j-core/src/main/java/com/pi4j/wiringpi/Lcd.java
+++ b/pi4j-core/src/main/java/com/pi4j/wiringpi/Lcd.java
@@ -11,7 +11,7 @@ package com.pi4j.wiringpi;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -84,7 +84,7 @@ public class Lcd {
     
     static {
         // Load the platform library
-        NativeLibraryLoader.load("pi4j", "libpi4j.so");
+        NativeLibraryLoader.load("libpi4j.so");
     }
 
     /**

--- a/pi4j-core/src/main/java/com/pi4j/wiringpi/Nes.java
+++ b/pi4j-core/src/main/java/com/pi4j/wiringpi/Nes.java
@@ -11,7 +11,7 @@ package com.pi4j.wiringpi;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -69,7 +69,7 @@ public class Nes {
     
     static {
         // Load the platform library
-        NativeLibraryLoader.load("pi4j", "libpi4j.so");
+        NativeLibraryLoader.load("libpi4j.so");
     }
 
     /**

--- a/pi4j-core/src/main/java/com/pi4j/wiringpi/Serial.java
+++ b/pi4j-core/src/main/java/com/pi4j/wiringpi/Serial.java
@@ -11,7 +11,7 @@ package com.pi4j.wiringpi;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -78,7 +78,7 @@ public class Serial {
     
     static {
         // Load the platform library
-        NativeLibraryLoader.load("pi4j", "libpi4j.so");
+        NativeLibraryLoader.load("libpi4j.so");
     }
 
     /**

--- a/pi4j-core/src/main/java/com/pi4j/wiringpi/Shift.java
+++ b/pi4j-core/src/main/java/com/pi4j/wiringpi/Shift.java
@@ -11,7 +11,7 @@ package com.pi4j.wiringpi;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -70,7 +70,7 @@ public class Shift {
     
     static {
         // Load the platform library
-        NativeLibraryLoader.load("pi4j", "libpi4j.so");
+        NativeLibraryLoader.load("libpi4j.so");
     }
 
     /**

--- a/pi4j-core/src/main/java/com/pi4j/wiringpi/SoftPwm.java
+++ b/pi4j-core/src/main/java/com/pi4j/wiringpi/SoftPwm.java
@@ -11,7 +11,7 @@ package com.pi4j.wiringpi;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -88,7 +88,7 @@ public class SoftPwm {
     
     static {
         // Load the platform library
-        NativeLibraryLoader.load("pi4j", "libpi4j.so");
+        NativeLibraryLoader.load("libpi4j.so");
     }
 
     /**

--- a/pi4j-core/src/main/java/com/pi4j/wiringpi/Spi.java
+++ b/pi4j-core/src/main/java/com/pi4j/wiringpi/Spi.java
@@ -11,7 +11,7 @@ package com.pi4j.wiringpi;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -89,7 +89,7 @@ public class Spi {
     
     static {
         // Load the platform library
-        NativeLibraryLoader.load("pi4j", "libpi4j.so");
+        NativeLibraryLoader.load("libpi4j.so");
     }
 
     /**

--- a/pi4j-core/src/test/java/com/pi4j/io/gpio/test/GpioPinAnalogInputTests.java
+++ b/pi4j-core/src/test/java/com/pi4j/io/gpio/test/GpioPinAnalogInputTests.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio.test;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/test/java/com/pi4j/io/gpio/test/GpioPinAnalogOutputTests.java
+++ b/pi4j-core/src/test/java/com/pi4j/io/gpio/test/GpioPinAnalogOutputTests.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio.test;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/test/java/com/pi4j/io/gpio/test/GpioPinDigitalInputTests.java
+++ b/pi4j-core/src/test/java/com/pi4j/io/gpio/test/GpioPinDigitalInputTests.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio.test;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/test/java/com/pi4j/io/gpio/test/GpioPinDigitalOutputTests.java
+++ b/pi4j-core/src/test/java/com/pi4j/io/gpio/test/GpioPinDigitalOutputTests.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio.test;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/test/java/com/pi4j/io/gpio/test/GpioPinPwmOutputTests.java
+++ b/pi4j-core/src/test/java/com/pi4j/io/gpio/test/GpioPinPwmOutputTests.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio.test;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/test/java/com/pi4j/io/gpio/test/MockGpioFactory.java
+++ b/pi4j-core/src/test/java/com/pi4j/io/gpio/test/MockGpioFactory.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio.test;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/test/java/com/pi4j/io/gpio/test/MockGpioProvider.java
+++ b/pi4j-core/src/test/java/com/pi4j/io/gpio/test/MockGpioProvider.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio.test;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/test/java/com/pi4j/io/gpio/test/MockPin.java
+++ b/pi4j-core/src/test/java/com/pi4j/io/gpio/test/MockPin.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio.test;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/test/java/com/pi4j/io/gpio/trigger/test/GpioCallbackTriggerTests.java
+++ b/pi4j-core/src/test/java/com/pi4j/io/gpio/trigger/test/GpioCallbackTriggerTests.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio.trigger.test;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/test/java/com/pi4j/io/gpio/trigger/test/GpioInverseSyncStateTriggerTests.java
+++ b/pi4j-core/src/test/java/com/pi4j/io/gpio/trigger/test/GpioInverseSyncStateTriggerTests.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio.trigger.test;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/test/java/com/pi4j/io/gpio/trigger/test/GpioPulseStateTriggerTests.java
+++ b/pi4j-core/src/test/java/com/pi4j/io/gpio/trigger/test/GpioPulseStateTriggerTests.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio.trigger.test;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/test/java/com/pi4j/io/gpio/trigger/test/GpioSetStateTriggerTests.java
+++ b/pi4j-core/src/test/java/com/pi4j/io/gpio/trigger/test/GpioSetStateTriggerTests.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio.trigger.test;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/test/java/com/pi4j/io/gpio/trigger/test/GpioSyncStateTriggerTests.java
+++ b/pi4j-core/src/test/java/com/pi4j/io/gpio/trigger/test/GpioSyncStateTriggerTests.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio.trigger.test;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/test/java/com/pi4j/io/gpio/trigger/test/GpioToggleStateTriggerTests.java
+++ b/pi4j-core/src/test/java/com/pi4j/io/gpio/trigger/test/GpioToggleStateTriggerTests.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio.trigger.test;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/test/java/com/pi4j/temperature/test/TemperatureConversionTests.java
+++ b/pi4j-core/src/test/java/com/pi4j/temperature/test/TemperatureConversionTests.java
@@ -11,7 +11,7 @@ package com.pi4j.temperature.test;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-core/src/test/java/com/pi4j/util/StringUtilTests.java
+++ b/pi4j-core/src/test/java/com/pi4j/util/StringUtilTests.java
@@ -11,7 +11,7 @@ package com.pi4j.util;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/component/Component.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/Component.java
@@ -13,7 +13,7 @@ import java.util.Map;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/component/ComponentBase.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/ComponentBase.java
@@ -11,7 +11,7 @@ package com.pi4j.component;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/component/ComponentListener.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/ComponentListener.java
@@ -11,7 +11,7 @@ package com.pi4j.component;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/component/ObserveableComponent.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/ObserveableComponent.java
@@ -11,7 +11,7 @@ package com.pi4j.component;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/component/ObserveableComponentBase.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/ObserveableComponentBase.java
@@ -11,7 +11,7 @@ package com.pi4j.component;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/component/access/Keypad.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/access/Keypad.java
@@ -11,7 +11,7 @@ package com.pi4j.component.access;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/component/lcd/LCD.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/lcd/LCD.java
@@ -11,7 +11,7 @@ package com.pi4j.component.lcd;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/component/lcd/LCDBase.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/lcd/LCDBase.java
@@ -11,7 +11,7 @@ package com.pi4j.component.lcd;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/component/lcd/LCDTextAlignment.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/lcd/LCDTextAlignment.java
@@ -11,7 +11,7 @@ package com.pi4j.component.lcd;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/component/lcd/impl/GpioLcdDisplay.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/lcd/impl/GpioLcdDisplay.java
@@ -11,7 +11,7 @@ package com.pi4j.component.lcd.impl;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/component/light/DimmableLight.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/light/DimmableLight.java
@@ -13,7 +13,7 @@ import com.pi4j.component.ObserveableComponent;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/component/light/DimmableLightBase.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/light/DimmableLightBase.java
@@ -11,7 +11,7 @@ package com.pi4j.component.light;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/component/light/DimmableLightListener.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/light/DimmableLightListener.java
@@ -11,7 +11,7 @@ package com.pi4j.component.light;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/component/light/LED.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/light/LED.java
@@ -13,7 +13,7 @@ import java.util.concurrent.Future;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/component/light/LEDBase.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/light/LEDBase.java
@@ -11,7 +11,7 @@ package com.pi4j.component.light;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/component/light/Light.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/light/Light.java
@@ -11,7 +11,7 @@ package com.pi4j.component.light;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/component/light/LightBase.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/light/LightBase.java
@@ -11,7 +11,7 @@ package com.pi4j.component.light;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/component/light/LightLevelChangeEvent.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/light/LightLevelChangeEvent.java
@@ -11,7 +11,7 @@ package com.pi4j.component.light;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/component/light/LightListener.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/light/LightListener.java
@@ -11,7 +11,7 @@ package com.pi4j.component.light;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/component/light/LightStateChangeEvent.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/light/LightStateChangeEvent.java
@@ -11,7 +11,7 @@ package com.pi4j.component.light;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/component/light/impl/GpioDimmableLightComponent.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/light/impl/GpioDimmableLightComponent.java
@@ -11,7 +11,7 @@ package com.pi4j.component.light.impl;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/component/light/impl/GpioLEDComponent.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/light/impl/GpioLEDComponent.java
@@ -11,7 +11,7 @@ package com.pi4j.component.light.impl;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/component/light/impl/GpioLightComponent.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/light/impl/GpioLightComponent.java
@@ -11,7 +11,7 @@ package com.pi4j.component.light.impl;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/component/motor/Motor.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/motor/Motor.java
@@ -11,7 +11,7 @@ package com.pi4j.component.motor;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/component/motor/MotorBase.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/motor/MotorBase.java
@@ -11,7 +11,7 @@ package com.pi4j.component.motor;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/component/motor/MotorState.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/motor/MotorState.java
@@ -11,7 +11,7 @@ package com.pi4j.component.motor;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/component/motor/StepperMotor.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/motor/StepperMotor.java
@@ -11,7 +11,7 @@ package com.pi4j.component.motor;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/component/motor/StepperMotorBase.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/motor/StepperMotorBase.java
@@ -11,7 +11,7 @@ package com.pi4j.component.motor;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/component/motor/impl/GpioStepperMotorComponent.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/motor/impl/GpioStepperMotorComponent.java
@@ -11,7 +11,7 @@ package com.pi4j.component.motor.impl;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/component/power/Power.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/power/Power.java
@@ -13,7 +13,7 @@ import com.pi4j.component.ObserveableComponent;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/component/power/PowerBase.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/power/PowerBase.java
@@ -14,7 +14,7 @@ import com.pi4j.component.ObserveableComponentBase;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/component/power/PowerListener.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/power/PowerListener.java
@@ -11,7 +11,7 @@ package com.pi4j.component.power;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/component/power/PowerState.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/power/PowerState.java
@@ -11,7 +11,7 @@ package com.pi4j.component.power;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/component/power/PowerStateChangeEvent.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/power/PowerStateChangeEvent.java
@@ -11,7 +11,7 @@ package com.pi4j.component.power;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/component/power/impl/GpioPowerComponent.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/power/impl/GpioPowerComponent.java
@@ -11,7 +11,7 @@ package com.pi4j.component.power.impl;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/component/relay/Relay.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/relay/Relay.java
@@ -11,7 +11,7 @@ package com.pi4j.component.relay;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/component/relay/RelayBase.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/relay/RelayBase.java
@@ -14,7 +14,7 @@ import com.pi4j.component.ObserveableComponentBase;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/component/relay/RelayListener.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/relay/RelayListener.java
@@ -11,7 +11,7 @@ package com.pi4j.component.relay;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/component/relay/RelayState.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/relay/RelayState.java
@@ -11,7 +11,7 @@ package com.pi4j.component.relay;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/component/relay/RelayStateChangeEvent.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/relay/RelayStateChangeEvent.java
@@ -11,7 +11,7 @@ package com.pi4j.component.relay;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/component/relay/impl/GpioRelayComponent.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/relay/impl/GpioRelayComponent.java
@@ -11,7 +11,7 @@ package com.pi4j.component.relay.impl;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/component/sensor/MotionSensor.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/sensor/MotionSensor.java
@@ -11,7 +11,7 @@ package com.pi4j.component.sensor;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/component/sensor/MotionSensorBase.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/sensor/MotionSensorBase.java
@@ -11,7 +11,7 @@ package com.pi4j.component.sensor;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/component/sensor/MotionSensorChangeEvent.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/sensor/MotionSensorChangeEvent.java
@@ -11,7 +11,7 @@ package com.pi4j.component.sensor;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/component/sensor/MotionSensorListener.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/sensor/MotionSensorListener.java
@@ -11,7 +11,7 @@ package com.pi4j.component.sensor;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/component/sensor/Sensor.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/sensor/Sensor.java
@@ -11,7 +11,7 @@ package com.pi4j.component.sensor;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/component/sensor/SensorBase.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/sensor/SensorBase.java
@@ -14,7 +14,7 @@ import com.pi4j.component.ObserveableComponentBase;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/component/sensor/SensorListener.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/sensor/SensorListener.java
@@ -11,7 +11,7 @@ package com.pi4j.component.sensor;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/component/sensor/SensorState.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/sensor/SensorState.java
@@ -11,7 +11,7 @@ package com.pi4j.component.sensor;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/component/sensor/SensorStateChangeEvent.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/sensor/SensorStateChangeEvent.java
@@ -11,7 +11,7 @@ package com.pi4j.component.sensor;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/component/sensor/impl/GpioMotionSensorComponent.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/sensor/impl/GpioMotionSensorComponent.java
@@ -11,7 +11,7 @@ package com.pi4j.component.sensor.impl;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/component/sensor/impl/GpioSensorComponent.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/sensor/impl/GpioSensorComponent.java
@@ -11,7 +11,7 @@ package com.pi4j.component.sensor.impl;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/component/switches/MomentarySwitch.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/switches/MomentarySwitch.java
@@ -11,7 +11,7 @@ package com.pi4j.component.switches;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/component/switches/MomentarySwitchBase.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/switches/MomentarySwitchBase.java
@@ -11,7 +11,7 @@ package com.pi4j.component.switches;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/component/switches/Switch.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/switches/Switch.java
@@ -11,7 +11,7 @@ package com.pi4j.component.switches;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/component/switches/SwitchBase.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/switches/SwitchBase.java
@@ -14,7 +14,7 @@ import com.pi4j.component.ObserveableComponentBase;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/component/switches/SwitchListener.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/switches/SwitchListener.java
@@ -11,7 +11,7 @@ package com.pi4j.component.switches;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/component/switches/SwitchState.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/switches/SwitchState.java
@@ -11,7 +11,7 @@ package com.pi4j.component.switches;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/component/switches/SwitchStateChangeEvent.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/switches/SwitchStateChangeEvent.java
@@ -11,7 +11,7 @@ package com.pi4j.component.switches;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/component/switches/ToggleSwitch.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/switches/ToggleSwitch.java
@@ -11,7 +11,7 @@ package com.pi4j.component.switches;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/component/switches/ToggleSwitchBase.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/switches/ToggleSwitchBase.java
@@ -11,7 +11,7 @@ package com.pi4j.component.switches;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/component/switches/impl/GpioMomentarySwitchComponent.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/switches/impl/GpioMomentarySwitchComponent.java
@@ -11,7 +11,7 @@ package com.pi4j.component.switches.impl;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/component/switches/impl/GpioSwitchComponent.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/switches/impl/GpioSwitchComponent.java
@@ -11,7 +11,7 @@ package com.pi4j.component.switches.impl;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/component/switches/impl/GpioToggleSwitchComponent.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/switches/impl/GpioToggleSwitchComponent.java
@@ -11,7 +11,7 @@ package com.pi4j.component.switches.impl;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/component/temperature/TemperatureChangeEvent.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/temperature/TemperatureChangeEvent.java
@@ -11,7 +11,7 @@ package com.pi4j.component.temperature;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/component/temperature/TemperatureController.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/temperature/TemperatureController.java
@@ -11,7 +11,7 @@ package com.pi4j.component.temperature;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/component/temperature/TemperatureControllerBase.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/temperature/TemperatureControllerBase.java
@@ -14,7 +14,7 @@ import com.pi4j.temperature.TemperatureScale;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/component/temperature/TemperatureListener.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/temperature/TemperatureListener.java
@@ -11,7 +11,7 @@ package com.pi4j.component.temperature;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/component/temperature/TemperatureSensor.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/temperature/TemperatureSensor.java
@@ -11,7 +11,7 @@ package com.pi4j.component.temperature;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/component/temperature/TemperatureSensorBase.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/temperature/TemperatureSensorBase.java
@@ -16,7 +16,7 @@ import com.pi4j.temperature.TemperatureScale;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/device/Device.java
+++ b/pi4j-device/src/main/java/com/pi4j/device/Device.java
@@ -13,7 +13,7 @@ import java.util.Map;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/device/DeviceBase.java
+++ b/pi4j-device/src/main/java/com/pi4j/device/DeviceBase.java
@@ -11,7 +11,7 @@ package com.pi4j.device;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/device/DeviceListener.java
+++ b/pi4j-device/src/main/java/com/pi4j/device/DeviceListener.java
@@ -11,7 +11,7 @@ package com.pi4j.device;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/device/ObserveableDevice.java
+++ b/pi4j-device/src/main/java/com/pi4j/device/ObserveableDevice.java
@@ -11,7 +11,7 @@ package com.pi4j.device;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/device/ObserveableDeviceBase.java
+++ b/pi4j-device/src/main/java/com/pi4j/device/ObserveableDeviceBase.java
@@ -11,7 +11,7 @@ package com.pi4j.device;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/device/access/Opener.java
+++ b/pi4j-device/src/main/java/com/pi4j/device/access/Opener.java
@@ -11,7 +11,7 @@ package com.pi4j.device.access;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/device/access/OpenerBase.java
+++ b/pi4j-device/src/main/java/com/pi4j/device/access/OpenerBase.java
@@ -11,7 +11,7 @@ package com.pi4j.device.access;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/device/access/OpenerControlState.java
+++ b/pi4j-device/src/main/java/com/pi4j/device/access/OpenerControlState.java
@@ -11,7 +11,7 @@ package com.pi4j.device.access;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/device/access/OpenerListener.java
+++ b/pi4j-device/src/main/java/com/pi4j/device/access/OpenerListener.java
@@ -11,7 +11,7 @@ package com.pi4j.device.access;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/device/access/OpenerLockChangeEvent.java
+++ b/pi4j-device/src/main/java/com/pi4j/device/access/OpenerLockChangeEvent.java
@@ -11,7 +11,7 @@ package com.pi4j.device.access;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/device/access/OpenerLockedException.java
+++ b/pi4j-device/src/main/java/com/pi4j/device/access/OpenerLockedException.java
@@ -11,7 +11,7 @@ package com.pi4j.device.access;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/device/access/OpenerState.java
+++ b/pi4j-device/src/main/java/com/pi4j/device/access/OpenerState.java
@@ -11,7 +11,7 @@ package com.pi4j.device.access;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/device/access/OpenerStateChangeEvent.java
+++ b/pi4j-device/src/main/java/com/pi4j/device/access/OpenerStateChangeEvent.java
@@ -11,7 +11,7 @@ package com.pi4j.device.access;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/device/access/impl/OpenerDevice.java
+++ b/pi4j-device/src/main/java/com/pi4j/device/access/impl/OpenerDevice.java
@@ -11,7 +11,7 @@ package com.pi4j.device.access.impl;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/device/garage/GarageDoorOpener.java
+++ b/pi4j-device/src/main/java/com/pi4j/device/garage/GarageDoorOpener.java
@@ -11,7 +11,7 @@ package com.pi4j.device.garage;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/device/garage/GarageDoorOpenerBase.java
+++ b/pi4j-device/src/main/java/com/pi4j/device/garage/GarageDoorOpenerBase.java
@@ -11,7 +11,7 @@ package com.pi4j.device.garage;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/device/garage/impl/GarageDoorOpenerDevice.java
+++ b/pi4j-device/src/main/java/com/pi4j/device/garage/impl/GarageDoorOpenerDevice.java
@@ -11,7 +11,7 @@ package com.pi4j.device.garage.impl;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/device/gate/GateOpener.java
+++ b/pi4j-device/src/main/java/com/pi4j/device/gate/GateOpener.java
@@ -11,7 +11,7 @@ package com.pi4j.device.gate;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/device/gate/GateOpenerBase.java
+++ b/pi4j-device/src/main/java/com/pi4j/device/gate/GateOpenerBase.java
@@ -11,7 +11,7 @@ package com.pi4j.device.gate;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/device/gate/impl/GateOpenerDevice.java
+++ b/pi4j-device/src/main/java/com/pi4j/device/gate/impl/GateOpenerDevice.java
@@ -11,7 +11,7 @@ package com.pi4j.device.gate.impl;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/device/piface/PiFace.java
+++ b/pi4j-device/src/main/java/com/pi4j/device/piface/PiFace.java
@@ -11,7 +11,7 @@ package com.pi4j.device.piface;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/device/piface/PiFaceBase.java
+++ b/pi4j-device/src/main/java/com/pi4j/device/piface/PiFaceBase.java
@@ -11,7 +11,7 @@ package com.pi4j.device.piface;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/device/piface/PiFaceLed.java
+++ b/pi4j-device/src/main/java/com/pi4j/device/piface/PiFaceLed.java
@@ -11,7 +11,7 @@ package com.pi4j.device.piface;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/device/piface/PiFaceRelay.java
+++ b/pi4j-device/src/main/java/com/pi4j/device/piface/PiFaceRelay.java
@@ -11,7 +11,7 @@ package com.pi4j.device.piface;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/device/piface/PiFaceSwitch.java
+++ b/pi4j-device/src/main/java/com/pi4j/device/piface/PiFaceSwitch.java
@@ -11,7 +11,7 @@ package com.pi4j.device.piface;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/device/piface/impl/PiFaceDevice.java
+++ b/pi4j-device/src/main/java/com/pi4j/device/piface/impl/PiFaceDevice.java
@@ -11,7 +11,7 @@ package com.pi4j.device.piface.impl;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/device/sprinkler/SprinklerController.java
+++ b/pi4j-device/src/main/java/com/pi4j/device/sprinkler/SprinklerController.java
@@ -11,7 +11,7 @@ package com.pi4j.device.sprinkler;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/device/sprinkler/SprinklerControllerBase.java
+++ b/pi4j-device/src/main/java/com/pi4j/device/sprinkler/SprinklerControllerBase.java
@@ -11,7 +11,7 @@ package com.pi4j.device.sprinkler;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/device/sprinkler/SprinklerZone.java
+++ b/pi4j-device/src/main/java/com/pi4j/device/sprinkler/SprinklerZone.java
@@ -11,7 +11,7 @@ package com.pi4j.device.sprinkler;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-device/src/main/java/com/pi4j/device/sprinkler/SprinklerZoneBase.java
+++ b/pi4j-device/src/main/java/com/pi4j/device/sprinkler/SprinklerZoneBase.java
@@ -11,7 +11,7 @@ package com.pi4j.device.sprinkler;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-example/src/main/java/BlinkGpioExample.java
+++ b/pi4j-example/src/main/java/BlinkGpioExample.java
@@ -12,7 +12,7 @@
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-example/src/main/java/BlinkTriggerGpioExample.java
+++ b/pi4j-example/src/main/java/BlinkTriggerGpioExample.java
@@ -12,7 +12,7 @@
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-example/src/main/java/ControlGpioExample.java
+++ b/pi4j-example/src/main/java/ControlGpioExample.java
@@ -11,7 +11,7 @@
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-example/src/main/java/CylonGpioExample.java
+++ b/pi4j-example/src/main/java/CylonGpioExample.java
@@ -12,7 +12,7 @@
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-example/src/main/java/FrequencyGpioExample.java
+++ b/pi4j-example/src/main/java/FrequencyGpioExample.java
@@ -12,7 +12,7 @@
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-example/src/main/java/I2CWiiMotionPlusExample.java
+++ b/pi4j-example/src/main/java/I2CWiiMotionPlusExample.java
@@ -9,7 +9,7 @@
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-example/src/main/java/LcdExample.java
+++ b/pi4j-example/src/main/java/LcdExample.java
@@ -10,7 +10,7 @@
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-example/src/main/java/ListenGpioExample.java
+++ b/pi4j-example/src/main/java/ListenGpioExample.java
@@ -12,7 +12,7 @@
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-example/src/main/java/ListenMultipleGpioExample.java
+++ b/pi4j-example/src/main/java/ListenMultipleGpioExample.java
@@ -12,7 +12,7 @@
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-example/src/main/java/MCP23017GpioExample.java
+++ b/pi4j-example/src/main/java/MCP23017GpioExample.java
@@ -11,7 +11,7 @@
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-example/src/main/java/MCP23S17GpioExample.java
+++ b/pi4j-example/src/main/java/MCP23S17GpioExample.java
@@ -11,7 +11,7 @@
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-example/src/main/java/MultipurposePinGpioExample.java
+++ b/pi4j-example/src/main/java/MultipurposePinGpioExample.java
@@ -9,7 +9,7 @@
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-example/src/main/java/OlimexGpioExample.java
+++ b/pi4j-example/src/main/java/OlimexGpioExample.java
@@ -11,7 +11,7 @@
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-example/src/main/java/PCF8574GpioExample.java
+++ b/pi4j-example/src/main/java/PCF8574GpioExample.java
@@ -9,7 +9,7 @@
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-example/src/main/java/PiFaceExample.java
+++ b/pi4j-example/src/main/java/PiFaceExample.java
@@ -11,7 +11,7 @@
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-example/src/main/java/PiFaceGpioExample.java
+++ b/pi4j-example/src/main/java/PiFaceGpioExample.java
@@ -11,7 +11,7 @@
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-example/src/main/java/SerialExample.java
+++ b/pi4j-example/src/main/java/SerialExample.java
@@ -12,7 +12,7 @@
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-example/src/main/java/ShutdownGpioExample.java
+++ b/pi4j-example/src/main/java/ShutdownGpioExample.java
@@ -12,7 +12,7 @@
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-example/src/main/java/StepperMotorGpioExample.java
+++ b/pi4j-example/src/main/java/StepperMotorGpioExample.java
@@ -9,7 +9,7 @@
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-example/src/main/java/SystemInfoExample.java
+++ b/pi4j-example/src/main/java/SystemInfoExample.java
@@ -12,7 +12,7 @@
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-example/src/main/java/TriggerGpioExample.java
+++ b/pi4j-example/src/main/java/TriggerGpioExample.java
@@ -12,7 +12,7 @@
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-example/src/main/java/UsageGpioExample.java
+++ b/pi4j-example/src/main/java/UsageGpioExample.java
@@ -11,7 +11,7 @@
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License"); you
  * may not use this file except in compliance with the License. You may obtain a copy of the License

--- a/pi4j-example/src/main/java/WiringPiGpioExample.java
+++ b/pi4j-example/src/main/java/WiringPiGpioExample.java
@@ -10,7 +10,7 @@
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-example/src/main/java/WiringPiGpioInterruptExample.java
+++ b/pi4j-example/src/main/java/WiringPiGpioInterruptExample.java
@@ -10,7 +10,7 @@
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-example/src/main/java/WiringPiLcdExample.java
+++ b/pi4j-example/src/main/java/WiringPiLcdExample.java
@@ -10,7 +10,7 @@
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-example/src/main/java/WiringPiSPIExample.java
+++ b/pi4j-example/src/main/java/WiringPiSPIExample.java
@@ -9,7 +9,7 @@
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-example/src/main/java/WiringPiSerialExample.java
+++ b/pi4j-example/src/main/java/WiringPiSerialExample.java
@@ -10,7 +10,7 @@
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-example/src/main/java/WiringPiSoftPWMExample.java
+++ b/pi4j-example/src/main/java/WiringPiSoftPWMExample.java
@@ -9,7 +9,7 @@
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-gpio-extension/src/main/java/com/pi4j/gpio/extension/mcp/MCP23008GpioProvider.java
+++ b/pi4j-gpio-extension/src/main/java/com/pi4j/gpio/extension/mcp/MCP23008GpioProvider.java
@@ -29,7 +29,7 @@ import com.pi4j.io.i2c.I2CFactory;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-gpio-extension/src/main/java/com/pi4j/gpio/extension/mcp/MCP23008Pin.java
+++ b/pi4j-gpio-extension/src/main/java/com/pi4j/gpio/extension/mcp/MCP23008Pin.java
@@ -17,7 +17,7 @@ import com.pi4j.io.gpio.impl.PinImpl;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License"); you
  * may not use this file except in compliance with the License. You may obtain a copy of the License

--- a/pi4j-gpio-extension/src/main/java/com/pi4j/gpio/extension/mcp/MCP23017GpioProvider.java
+++ b/pi4j-gpio-extension/src/main/java/com/pi4j/gpio/extension/mcp/MCP23017GpioProvider.java
@@ -29,7 +29,7 @@ import com.pi4j.io.i2c.I2CFactory;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License"); you
  * may not use this file except in compliance with the License. You may obtain a copy of the License

--- a/pi4j-gpio-extension/src/main/java/com/pi4j/gpio/extension/mcp/MCP23017Pin.java
+++ b/pi4j-gpio-extension/src/main/java/com/pi4j/gpio/extension/mcp/MCP23017Pin.java
@@ -18,7 +18,7 @@ import com.pi4j.io.gpio.impl.PinImpl;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License"); you
  * may not use this file except in compliance with the License. You may obtain a copy of the License

--- a/pi4j-gpio-extension/src/main/java/com/pi4j/gpio/extension/mcp/MCP23S17GpioProvider.java
+++ b/pi4j-gpio-extension/src/main/java/com/pi4j/gpio/extension/mcp/MCP23S17GpioProvider.java
@@ -27,7 +27,7 @@ import com.pi4j.wiringpi.Spi;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License"); you
  * may not use this file except in compliance with the License. You may obtain a copy of the License

--- a/pi4j-gpio-extension/src/main/java/com/pi4j/gpio/extension/mcp/MCP23S17Pin.java
+++ b/pi4j-gpio-extension/src/main/java/com/pi4j/gpio/extension/mcp/MCP23S17Pin.java
@@ -18,7 +18,7 @@ import com.pi4j.io.gpio.impl.PinImpl;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License"); you
  * may not use this file except in compliance with the License. You may obtain a copy of the License

--- a/pi4j-gpio-extension/src/main/java/com/pi4j/gpio/extension/olimex/OlimexAVRIOGpioProvider.java
+++ b/pi4j-gpio-extension/src/main/java/com/pi4j/gpio/extension/olimex/OlimexAVRIOGpioProvider.java
@@ -24,7 +24,7 @@ import com.pi4j.io.serial.SerialFactory;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-gpio-extension/src/main/java/com/pi4j/gpio/extension/olimex/OlimexAVRIOPin.java
+++ b/pi4j-gpio-extension/src/main/java/com/pi4j/gpio/extension/olimex/OlimexAVRIOPin.java
@@ -16,7 +16,7 @@ import com.pi4j.io.gpio.impl.PinImpl;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License"); you
  * may not use this file except in compliance with the License. You may obtain a copy of the License

--- a/pi4j-gpio-extension/src/main/java/com/pi4j/gpio/extension/pcf/PCF8574GpioProvider.java
+++ b/pi4j-gpio-extension/src/main/java/com/pi4j/gpio/extension/pcf/PCF8574GpioProvider.java
@@ -11,7 +11,7 @@ package com.pi4j.gpio.extension.pcf;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-gpio-extension/src/main/java/com/pi4j/gpio/extension/pcf/PCF8574Pin.java
+++ b/pi4j-gpio-extension/src/main/java/com/pi4j/gpio/extension/pcf/PCF8574Pin.java
@@ -11,7 +11,7 @@ package com.pi4j.gpio.extension.pcf;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-gpio-extension/src/main/java/com/pi4j/gpio/extension/piface/PiFaceGpioProvider.java
+++ b/pi4j-gpio-extension/src/main/java/com/pi4j/gpio/extension/piface/PiFaceGpioProvider.java
@@ -27,7 +27,7 @@ import com.pi4j.wiringpi.Spi;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License"); you
  * may not use this file except in compliance with the License. You may obtain a copy of the License

--- a/pi4j-gpio-extension/src/main/java/com/pi4j/gpio/extension/piface/PiFacePin.java
+++ b/pi4j-gpio-extension/src/main/java/com/pi4j/gpio/extension/piface/PiFacePin.java
@@ -11,7 +11,7 @@ package com.pi4j.gpio.extension.piface;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-gpio-extension/src/main/java/com/pi4j/gpio/extension/serial/SerialCommandQueueProcessingThread.java
+++ b/pi4j-gpio-extension/src/main/java/com/pi4j/gpio/extension/serial/SerialCommandQueueProcessingThread.java
@@ -11,7 +11,7 @@ package com.pi4j.gpio.extension.serial;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-gpio-extension/src/main/native/olimex/avrio-m16/OlimexAvrIoM16-Pi4JGpioExtension.c
+++ b/pi4j-gpio-extension/src/main/native/olimex/avrio-m16/OlimexAvrIoM16-Pi4JGpioExtension.c
@@ -9,7 +9,7 @@
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-service/src/main/java/com/pi4j/io/gpio/service/GpioService.java
+++ b/pi4j-service/src/main/java/com/pi4j/io/gpio/service/GpioService.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio.service;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-service/src/main/java/com/pi4j/io/gpio/service/impl/GpioServiceImpl.java
+++ b/pi4j-service/src/main/java/com/pi4j/io/gpio/service/impl/GpioServiceImpl.java
@@ -11,7 +11,7 @@ package com.pi4j.io.gpio.service.impl;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-service/src/main/java/com/pi4j/service/osgi/Activator.java
+++ b/pi4j-service/src/main/java/com/pi4j/service/osgi/Activator.java
@@ -11,7 +11,7 @@ package com.pi4j.service.osgi;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-service/src/main/java/com/pi4j/system/service/NetworkInformationService.java
+++ b/pi4j-service/src/main/java/com/pi4j/system/service/NetworkInformationService.java
@@ -11,7 +11,7 @@ package com.pi4j.system.service;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-service/src/main/java/com/pi4j/system/service/SystemInformationService.java
+++ b/pi4j-service/src/main/java/com/pi4j/system/service/SystemInformationService.java
@@ -11,7 +11,7 @@ package com.pi4j.system.service;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-service/src/main/java/com/pi4j/system/service/impl/NetworkInformationServiceImpl.java
+++ b/pi4j-service/src/main/java/com/pi4j/system/service/impl/NetworkInformationServiceImpl.java
@@ -11,7 +11,7 @@ package com.pi4j.system.service.impl;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/pi4j-service/src/main/java/com/pi4j/system/service/impl/SystemInformationServiceImpl.java
+++ b/pi4j-service/src/main/java/com/pi4j/system/service/impl/SystemInformationServiceImpl.java
@@ -11,7 +11,7 @@ package com.pi4j.system.service.impl;
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************
  * %%
- * Copyright (C) 2012 - 2013 Pi4J
+ * Copyright (C) 2012 - 2014 Pi4J
  * %%
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
- simplified, only loading from embeded resource, trying both soft and
  hard versions
- fixes issues with redeployment in J2EE environments, since this method
  now effectively creates new so temp file each time it is invoked. All
  of the temp files then get deleted on web container shutdown
- dropped library name from the method too, only using the filename of
  the so library to load
- updated all client code
- eclipse seem to have updated many other comments and copyrights with
  current year too
- added more eclipse files to .gitignore
