### PR TITLE
allow native compilation to run on non-raspi boxes too

### DIFF
--- a/pi4j-example/src/main/java/SpiExample.java
+++ b/pi4j-example/src/main/java/SpiExample.java
@@ -3,7 +3,7 @@
  * **********************************************************************
  * ORGANIZATION  :  Pi4J
  * PROJECT       :  Pi4J :: Java Examples
- * FILENAME      :  example.java  
+ * FILENAME      :  SpiExample.java  
  * 
  * This file is part of the Pi4J project. More information about 
  * this project can be found here:  http://www.pi4j.com/

--- a/pi4j-native/src/main/native/install-prerequisites.sh
+++ b/pi4j-native/src/main/native/install-prerequisites.sh
@@ -27,6 +27,8 @@
 # ----------------------------------
 # install prerequisites
 # ----------------------------------
-sudo apt-get install gcc -y
-sudo apt-get install git-core -y
-sudo apt-get install oracle-java7-jdk -y
+if [ ! -z "`type apt-get 2>/dev/null;`" ]; then 
+  sudo apt-get install gcc -y
+  sudo apt-get install git-core -y
+  sudo apt-get install oracle-java7-jdk -y
+fi


### PR DESCRIPTION
apt-get command exists on Debian distributions only (ubuntu, raspian, etc). Since I run Gentoo on my raspberry pi, the compilation then failed in the install of prerequisites (which I already did manually before). So this check should make sure the apt-get commands are only run on distros with that command.
