### PR TITLE
After closing a I2CBus object, also forget the static bus instance

### DIFF
--- a/pi4j-core/src/main/java/com/pi4j/io/i2c/impl/I2CBusImplBananaPi.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/i2c/impl/I2CBusImplBananaPi.java
@@ -28,6 +28,7 @@ package com.pi4j.io.i2c.impl;
  */
 
 import com.pi4j.io.i2c.I2CBus;
+import com.pi4j.jni.I2C;
 
 import java.io.IOException;
 import java.util.concurrent.locks.Lock;

--- a/pi4j-core/src/main/java/com/pi4j/io/i2c/impl/I2CBusImplBananaPi.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/i2c/impl/I2CBusImplBananaPi.java
@@ -30,6 +30,8 @@ package com.pi4j.io.i2c.impl;
 import com.pi4j.io.i2c.I2CBus;
 
 import java.io.IOException;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * This is implementation of i2c bus. This class keeps underlying linux file descriptor of
@@ -54,6 +56,11 @@ public class I2CBusImplBananaPi extends I2CBusImpl {
     private static I2CBus bus3 = null;
 
     /** 
+     * to lock the creation/destruction of the bus singletons
+     */
+    private final static Lock lock = new ReentrantLock(true);
+
+    /**
      * Factory method that returns bus implementation.
      * 
      * @param busNumber bus number
@@ -62,6 +69,7 @@ public class I2CBusImplBananaPi extends I2CBusImpl {
      */
     public static I2CBus getBus(int busNumber) throws IOException {
         I2CBus bus;
+        lock.lock();
         if (busNumber == 0) {
             bus = bus0;
             if (bus == null) {
@@ -89,6 +97,7 @@ public class I2CBusImplBananaPi extends I2CBusImpl {
         } else {
             throw new IOException("Unknown bus number " + busNumber);
         }
+        lock.unlock();
         return bus;
     }
 
@@ -100,7 +109,30 @@ public class I2CBusImplBananaPi extends I2CBusImpl {
      * @throws IOException thrown in case that file cannot be opened
      */
     public I2CBusImplBananaPi(String filename) throws IOException {
-    	super(filename);
+        super(filename);
     }
 
- }
+    /**
+     * Closes this i2c bus
+     *
+     * @throws IOException never in this implementation
+     */
+    @Override
+    public void close() throws IOException {
+        lock.lock();
+        I2C.i2cClose(fd);
+        /* after closing the fd, we must "forget" the singleton bus instance, otherwise further request to this bus will
+         * always fail
+         */
+        if (this == bus0) {
+            bus0 = null;
+        } else if (this == bus1) {
+            bus1 = null;
+        } else if (this == bus2) {
+            bus2 = null;
+        } else if (this == bus3) {
+            bus3 = null;
+        }
+        lock.unlock();
+    }
+}


### PR DESCRIPTION
fixes #122 after closing the bus, set the static bus instance to null, forcing a recreation/reopen on next getBus() call... since this presents a potential race condition, protect the creation/deletion of the static bus instance with a ReentrantLock similar to the I2CDeviceImpl
