### PR TITLE
Address thread leaks around use of the debouncer

### DIFF
--- a/pi4j-core/src/main/java/com/pi4j/concurrent/DefaultExecutorServiceFactory.java
+++ b/pi4j-core/src/main/java/com/pi4j/concurrent/DefaultExecutorServiceFactory.java
@@ -30,6 +30,7 @@ package com.pi4j.concurrent;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -40,13 +41,37 @@ public class DefaultExecutorServiceFactory implements ExecutorServiceFactory {
 
     public static int MAX_THREADS_IN_POOL = 25;
     private static List<ExecutorService> singleThreadExecutorServices = new ArrayList<>();
-    private static ScheduledExecutorService scheduledExecutorService = null;
-    private static ScheduledExecutorServiceWrapper executorServiceWrapper = null;
+
+    // this seemingly odd pattern is the recommended way to lazy-initialize static fields in effective java.
+    // The static "holder" class doesn't have it's static initializer called until it is accessed - and it's not accessed until the
+    // getInternalScheduledExecutor() method is called.
+    //
+    // (see effective java item 71:Use lazy initialization judiciously)
+    private static class ScheduledExecutorServiceHolder {
+        static final ScheduledExecutorService heldExecutor = Executors.newScheduledThreadPool(MAX_THREADS_IN_POOL, getThreadFactory("pi4j-scheduled-executor-%d"));
+    }
+    private static ScheduledExecutorService getInternalScheduledExecutor() {
+        return ScheduledExecutorServiceHolder.heldExecutor;
+    }
+    private static class ScheduledExecutorServiceWrapperHolder {
+        static final ScheduledExecutorServiceWrapper heldWrapper = new ScheduledExecutorServiceWrapper(getInternalScheduledExecutor());
+    }
+
+    // follow a similar lazy initialization pattern for the gpio events
+    private static ScheduledExecutorServiceWrapper getServiceWrapper() {
+        return ScheduledExecutorServiceWrapperHolder.heldWrapper;
+    }
+    private static class GpioEventServiceHolder {
+        static final ExecutorService cachedExecutor = new ShutdownDisabledExecutorWrapper(Executors.newCachedThreadPool(getThreadFactory("pi4j-gpio-event-executor-%d")));
+    }
+    private static ExecutorService getInternalGpioExecutorService() {
+        return GpioEventServiceHolder.cachedExecutor;
+    }
 
     /**
      * return an instance to the thread factory used to create new executor services
      */
-    private ThreadFactory getThreadFactory(final String nameFormat) {
+    private static ThreadFactory getThreadFactory(final String nameFormat) {
         final ThreadFactory defaultThreadFactory = Executors.defaultThreadFactory();
         return new ThreadFactory() {
             final AtomicLong count = (nameFormat != null) ? new AtomicLong(0) : null;
@@ -62,62 +87,55 @@ public class DefaultExecutorServiceFactory implements ExecutorServiceFactory {
         };
     }
 
+
+
+
     /**
      * return an instance to the scheduled executor service (wrapper)
      */
     public ScheduledExecutorService getScheduledExecutorService() {
-        if (scheduledExecutorService == null) {
-            scheduledExecutorService = Executors.newScheduledThreadPool(MAX_THREADS_IN_POOL, getThreadFactory("pi4j-scheduled-executor-%d"));
-            executorServiceWrapper = new ScheduledExecutorServiceWrapper(scheduledExecutorService);
-        }
-
         // we return the protected wrapper to prevent any consumers from 
         // being able to shutdown the scheduled executor service
-        return executorServiceWrapper;
+        return getServiceWrapper();
+    }
+
+    @Override
+    public ExecutorService getGpioEventExecutorService() {
+        return getInternalGpioExecutorService();
     }
 
     /**
      * return a new instance of a single thread executor service
+     *
+     * This method is deprecated in favor of the getGpioEventExecutorService - which provides better guarantees around resource
+     * management
      */
-    public ExecutorService newSingleThreadExecutorService() {
-
-      return newSingleThreadExecutorService("pi4j-single-executor");
-    }
-
     @Override
-    public ExecutorService newSingleThreadExecutorService(String threadNamePattern) {
-          // create new single thread executor
-        ExecutorService singleThreadExecutorService = Executors.newSingleThreadExecutor(getThreadFactory("pi4j-single-executor-%d"));
-
-        // add new instance to managed collection
-        singleThreadExecutorServices.add(singleThreadExecutorService);
-
-        // return the new instance
-        return singleThreadExecutorService;
+    public ExecutorService newSingleThreadExecutorService() {
+       return Executors.newSingleThreadExecutor(getThreadFactory("pi4j-single-executor-%d"));
     }
 
     /**
      * shutdown executor threads
      */
     public void shutdown() {
-
         // shutdown each single thread executor in the managed collection
         for (ExecutorService singleThreadExecutorService : singleThreadExecutorServices) {
-            if (singleThreadExecutorService != null) {
-                if (!singleThreadExecutorService.isShutdown()) {
-                    // this is a forceful shutdown; 
-                    // don't wait for the active tasks to complete
-                    singleThreadExecutorService.shutdownNow();
-                }
-            }
+            shutdownExecutor(singleThreadExecutorService);
         }
 
-        // shutdown scheduled executor instance 
-        if (scheduledExecutorService != null) {
-            if (!scheduledExecutorService.isShutdown()) {
-                // this is a forceful shutdown; 
+        // shutdown scheduled executor instance
+        shutdownExecutor(getInternalScheduledExecutor());
+        shutdownExecutor(getInternalGpioExecutorService());
+
+    }
+
+    private void shutdownExecutor(ExecutorService executor) {
+        if (executor != null) {
+            if (!executor.isShutdown()) {
+                // this is a forceful shutdown;
                 // don't wait for the scheduled tasks to complete
-                scheduledExecutorService.shutdownNow();
+                executor.shutdownNow();
             }
         }
     }

--- a/pi4j-core/src/main/java/com/pi4j/concurrent/ExecutorServiceFactory.java
+++ b/pi4j-core/src/main/java/com/pi4j/concurrent/ExecutorServiceFactory.java
@@ -36,5 +36,6 @@ public interface ExecutorServiceFactory
 {
     public ScheduledExecutorService getScheduledExecutorService();
     public ExecutorService newSingleThreadExecutorService();
+    public ExecutorService newSingleThreadExecutorService(String threadNamePattern);
     public void shutdown();
 }

--- a/pi4j-core/src/main/java/com/pi4j/concurrent/ExecutorServiceFactory.java
+++ b/pi4j-core/src/main/java/com/pi4j/concurrent/ExecutorServiceFactory.java
@@ -35,7 +35,9 @@ import java.util.concurrent.ScheduledExecutorService;
 public interface ExecutorServiceFactory
 {
     public ScheduledExecutorService getScheduledExecutorService();
+    public ExecutorService getGpioEventExecutorService();
+
+    @Deprecated
     public ExecutorService newSingleThreadExecutorService();
-    public ExecutorService newSingleThreadExecutorService(String threadNamePattern);
     public void shutdown();
 }

--- a/pi4j-core/src/main/java/com/pi4j/concurrent/ScheduledExecutorServiceWrapper.java
+++ b/pi4j-core/src/main/java/com/pi4j/concurrent/ScheduledExecutorServiceWrapper.java
@@ -28,12 +28,14 @@ package com.pi4j.concurrent;
  */
 
 
-import java.util.Collection;
-import java.util.List;
 import java.util.concurrent.*;
 
 @SuppressWarnings("unused")
-public class ScheduledExecutorServiceWrapper implements ScheduledExecutorService {
+/**
+ * Extend the {@link ShutdownDisabledExecutorWrapper} to the also wrap the additional methods of the {@link ScheduledExecutorService}
+ * but still allow us to prevent others from shutting down the executor directly.
+ */
+public class ScheduledExecutorServiceWrapper extends ShutdownDisabledExecutorWrapper implements ScheduledExecutorService {
 
     private ScheduledExecutorService service;
     
@@ -42,74 +44,8 @@ public class ScheduledExecutorServiceWrapper implements ScheduledExecutorService
      * @param service executor service
      */
     public ScheduledExecutorServiceWrapper(ScheduledExecutorService service) {
+        super(service);
         this.service = service;
-    }
-    
-    @Override
-    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
-        return service.awaitTermination(timeout, unit);
-    }
-
-    @Override
-    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
-        return service.invokeAll(tasks);
-    }
-
-    @Override
-    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) 
-            throws InterruptedException {
-        return service.invokeAll(tasks, timeout, unit);
-    }
-
-    @Override
-    public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
-        return service.invokeAny(tasks);
-    }
-
-    @Override
-    public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
-            throws InterruptedException, ExecutionException, TimeoutException {
-        return service.invokeAny(tasks, timeout, unit);
-    }
-
-    @Override
-    public boolean isShutdown() {
-        return service.isShutdown();
-    }
-
-    @Override
-    public boolean isTerminated() {
-        return service.isShutdown();
-    }
-
-    @Override
-    public void shutdown() {
-        throw new UnsupportedOperationException("This scheduled executor service can only be shutdown by Pi4J.");
-    }
-
-    @Override
-    public List<Runnable> shutdownNow() {
-        throw new UnsupportedOperationException("This scheduled executor service can only be shutdown by Pi4J.");
-    }
-
-    @Override
-    public <T> Future<T> submit(Callable<T> task) {
-        return service.submit(task);
-    }
-
-    @Override
-    public Future<?> submit(Runnable task) {
-        return service.submit(task);
-    }
-
-    @Override
-    public <T> Future<T> submit(Runnable task, T result) {
-        return service.submit(task, result);
-    }
-
-    @Override
-    public void execute(Runnable command) {
-        service.execute(command);        
     }
 
     @Override
@@ -123,14 +59,12 @@ public class ScheduledExecutorServiceWrapper implements ScheduledExecutorService
     }
 
     @Override
-    public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period,
-            TimeUnit unit) {
+    public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period, TimeUnit unit) {
         return service.scheduleAtFixedRate(command, initialDelay, period, unit);
     }
 
     @Override
-    public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay,
-            long delay, TimeUnit unit) {
+    public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay, TimeUnit unit) {
         return service.scheduleWithFixedDelay(command, initialDelay, delay, unit);
     }
 }

--- a/pi4j-core/src/main/java/com/pi4j/concurrent/ShutdownDisabledExecutorWrapper.java
+++ b/pi4j-core/src/main/java/com/pi4j/concurrent/ShutdownDisabledExecutorWrapper.java
@@ -1,0 +1,113 @@
+package com.pi4j.concurrent;
+
+/*
+ * #%L
+ * **********************************************************************
+ * ORGANIZATION  :  Pi4J
+ * PROJECT       :  Pi4J :: Java Library (Core)
+ * FILENAME      :  ShutdownDisabledExecutorWrapper.java  
+ * 
+ * This file is part of the Pi4J project. More information about 
+ * this project can be found here:  http://www.pi4j.com/
+ * **********************************************************************
+ * %%
+ * Copyright (C) 2012 - 2015 Pi4J
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * Wrap an executor service but disable the shutdown method
+ */
+public class ShutdownDisabledExecutorWrapper implements ExecutorService {
+    private ExecutorService executorService;
+
+    public ShutdownDisabledExecutorWrapper(ExecutorService executorService) {
+        this.executorService = executorService;
+    }
+
+    @Override
+    public void shutdown() {
+        throw new UnsupportedOperationException("This scheduled executor service can only be shutdown by Pi4J.");
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+        throw new UnsupportedOperationException("This scheduled executor service can only be shutdown by Pi4J.");
+    }
+
+    @Override
+    public boolean isShutdown() {
+        return executorService.isShutdown();
+    }
+
+    @Override
+    public boolean isTerminated() {
+        return executorService.isTerminated();
+    }
+
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+        return executorService.awaitTermination(timeout, unit);
+    }
+
+    @Override
+    public <T> Future<T> submit(Callable<T> task) {
+        return executorService.submit(task);
+    }
+
+    @Override
+    public <T> Future<T> submit(Runnable task, T result) {
+        return executorService.submit(task, result);
+    }
+
+    @Override
+    public Future<?> submit(Runnable task) {
+        return executorService.submit(task);
+    }
+
+    @Override
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
+        return executorService.invokeAll(tasks);
+    }
+
+    @Override
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException {
+        return executorService.invokeAll(tasks, timeout, unit);
+    }
+
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
+        return executorService.invokeAny(tasks);
+    }
+
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+        return executorService.invokeAny(tasks, timeout, unit);
+    }
+
+    @Override
+    public void execute(Runnable command) {
+        executorService.execute(command);
+    }
+}

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/impl/GpioEventMonitorExecutorImpl.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/impl/GpioEventMonitorExecutorImpl.java
@@ -51,7 +51,7 @@ public class GpioEventMonitorExecutorImpl implements PinListener {
     
     public GpioEventMonitorExecutorImpl(GpioPinInput pin) {
         this.pin = pin;        
-        executor = GpioFactory.getExecutorServiceFactory().newSingleThreadExecutorService("pi4j-event-monitor-" + pin.getName());
+        executor = GpioFactory.getExecutorServiceFactory().getGpioEventExecutorService();
         scheduledExecutor = GpioFactory.getExecutorServiceFactory().getScheduledExecutorService();
     }
     

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/impl/GpioEventMonitorExecutorImpl.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/impl/GpioEventMonitorExecutorImpl.java
@@ -51,7 +51,7 @@ public class GpioEventMonitorExecutorImpl implements PinListener {
     
     public GpioEventMonitorExecutorImpl(GpioPinInput pin) {
         this.pin = pin;        
-        executor = GpioFactory.getExecutorServiceFactory().newSingleThreadExecutorService();
+        executor = GpioFactory.getExecutorServiceFactory().newSingleThreadExecutorService("pi4j-event-monitor-" + pin.getName());
         scheduledExecutor = GpioFactory.getExecutorServiceFactory().getScheduledExecutorService();
     }
     

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/tasks/impl/GpioEventDebounceTaskImpl.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/tasks/impl/GpioEventDebounceTaskImpl.java
@@ -42,7 +42,7 @@ public class GpioEventDebounceTaskImpl implements Runnable {
     private static ExecutorService executor;
 
     public GpioEventDebounceTaskImpl(GpioPinDigitalInput pin, PinState state) {
-        executor = GpioFactory.getExecutorServiceFactory().newSingleThreadExecutorService("pi4j-debounce-pin" + pin.getName() + "-state-" + state.getName());
+        executor = GpioFactory.getExecutorServiceFactory().getGpioEventExecutorService();
         this.originalPinState = state;
         this.pin = pin;
     }

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/tasks/impl/GpioEventDebounceTaskImpl.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/tasks/impl/GpioEventDebounceTaskImpl.java
@@ -42,7 +42,7 @@ public class GpioEventDebounceTaskImpl implements Runnable {
     private static ExecutorService executor;
 
     public GpioEventDebounceTaskImpl(GpioPinDigitalInput pin, PinState state) {
-        executor = GpioFactory.getExecutorServiceFactory().newSingleThreadExecutorService();
+        executor = GpioFactory.getExecutorServiceFactory().newSingleThreadExecutorService("pi4j-debounce-pin" + pin.getName() + "-state-" + state.getName());
         this.originalPinState = state;
         this.pin = pin;
     }


### PR DESCRIPTION
It can be difficult to know if there is a thread leak or if things are behaving normally when the threads use the default "pool-N-thread-Y" names.

When looking at a thread dump from my application, it wasn't clear if there was a thread leak in pi4j or just a ton of generic threads - this change helps identify that the threads came from pi4j and what they are used for
