### PR TITLE
update the maven javadoc plugin used

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -145,7 +145,7 @@
         <maven-dependency-plugin.version>2.8</maven-dependency-plugin.version>
         <maven-compiler-plugin.version>3.1</maven-compiler-plugin.version>
         <maven-source-plugin.version>2.3</maven-source-plugin.version>
-        <maven-javadoc-plugin.version>2.9.1</maven-javadoc-plugin.version>
+        <maven-javadoc-plugin.version>2.10.2</maven-javadoc-plugin.version>
         <maven-site-plugin.version>3.3</maven-site-plugin.version>
         <maven-assembly-plugin.version>2.4.1</maven-assembly-plugin.version>
         <maven-gpg-plugin.version>1.5</maven-gpg-plugin.version>


### PR DESCRIPTION
The javadoc plugin 2.9.1 has issues with certain versions of java (build wouldn't work for me until I bumped it up to 2.10.2)
