### PR TITLE
Update to build static libwiringPi.a based on current wiringPi project

### DIFF
--- a/pi4j-native/src/main/native/wiringpi-build.sh
+++ b/pi4j-native/src/main/native/wiringpi-build.sh
@@ -9,7 +9,7 @@
 # this project can be found here:  http://www.pi4j.com/
 # **********************************************************************
 # %%
-# Copyright (C) 2012 - 2013 Pi4J
+# Copyright (C) 2012 - 2015 Pi4J
 # %%
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -47,3 +47,6 @@ sudo make uninstall
 # ----------------------------------
 cd ..
 ./build
+cd wiringPi
+make static
+sudo make install-static


### PR DESCRIPTION
The current wiringPi project has changed how to build the static library. From the wiringPi/INSTALL:

...
If you want to install a static library, you may need to do this manually:

  cd wiringPi
  make static
  sudo make install-static
