### PR TITLE
GpioControllerImpl varargs issues

### DIFF
--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/impl/GpioControllerImpl.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/impl/GpioControllerImpl.java
@@ -114,7 +114,7 @@ public class GpioControllerImpl implements GpioController {
         }
         for (GpioPin p : pin) {
             // ensure the requested pin has been provisioned
-            if (!pins.contains(pin)) {
+            if (!pins.contains(p)) {
                 throw new GpioPinNotProvisionedException(p.getPin());
             }
             if (!p.isExported()) {
@@ -171,7 +171,7 @@ public class GpioControllerImpl implements GpioController {
         }
         for (GpioPin p : pin) {
             // ensure the requested pin has been provisioned
-            if (!pins.contains(pin)) {
+            if (!pins.contains(p)) {
                 throw new GpioPinNotProvisionedException(p.getPin());
             }
             // set pin mode
@@ -229,7 +229,7 @@ public class GpioControllerImpl implements GpioController {
         }
         // ensure the requested pin has been provisioned
         for (GpioPinDigitalOutput p : pin) {
-            if (!pins.contains(pin)) {
+            if (!pins.contains(p)) {
                 throw new GpioPinNotProvisionedException(p.getPin());
             }
             // set pin state high


### PR DESCRIPTION
Had an issue with `isExported(GpioPin... pin)` throwing when it shouldn't have been.  Found the vararg array being passed into the `pins.contains` rather than the loop var.  There were a couple other instances of the same thing, fixed those up as well.
