### PR TITLE
initialize test class state for every @Test

### DIFF
--- a/pi4j-core/src/test/java/com/pi4j/io/gpio/test/GpioPinAnalogInputTests.java
+++ b/pi4j-core/src/test/java/com/pi4j/io/gpio/test/GpioPinAnalogInputTests.java
@@ -28,14 +28,12 @@ package com.pi4j.io.gpio.test;
  * <http://www.gnu.org/licenses/lgpl-3.0.html>.
  * #L%
  */
-
-
 import static org.junit.Assert.*;
 
 import java.util.Collection;
 import java.util.Random;
 
-import org.junit.BeforeClass;
+import org.junit.Before;
 import org.junit.Test;
 
 import com.pi4j.io.gpio.GpioController;
@@ -60,8 +58,8 @@ public class GpioPinAnalogInputTests {
     private static Double pinMonitoredValue;
     private static int eventCounter;
 
-    @BeforeClass 
-    public static void setup() {
+    @Before
+    public void setup() {
         // create a mock gpio provider and controller
         provider = MockGpioFactory.getMockProvider();
         gpio = MockGpioFactory.getInstance();

--- a/pi4j-core/src/test/java/com/pi4j/io/gpio/test/GpioPinAnalogOutputTests.java
+++ b/pi4j-core/src/test/java/com/pi4j/io/gpio/test/GpioPinAnalogOutputTests.java
@@ -28,14 +28,12 @@ package com.pi4j.io.gpio.test;
  * <http://www.gnu.org/licenses/lgpl-3.0.html>.
  * #L%
  */
-
-
 import static org.junit.Assert.*;
 
 import java.util.Collection;
 import java.util.Random;
 
-import org.junit.BeforeClass;
+import org.junit.Before;
 import org.junit.Test;
 
 import com.pi4j.io.gpio.GpioController;
@@ -53,8 +51,8 @@ public class GpioPinAnalogOutputTests {
     private static GpioController gpio;
     private static GpioPinAnalogOutput pin;
     
-    @BeforeClass 
-    public static void setup() {
+    @Before 
+    public void setup() {
         // create a mock gpio provider and controller
         gpio = MockGpioFactory.getInstance();
         

--- a/pi4j-core/src/test/java/com/pi4j/io/gpio/test/GpioPinDigitalInputTests.java
+++ b/pi4j-core/src/test/java/com/pi4j/io/gpio/test/GpioPinDigitalInputTests.java
@@ -28,13 +28,11 @@ package com.pi4j.io.gpio.test;
  * <http://www.gnu.org/licenses/lgpl-3.0.html>.
  * #L%
  */
-
-
 import static org.junit.Assert.*;
 
 import java.util.Collection;
 
-import org.junit.BeforeClass;
+import org.junit.Before;
 import org.junit.Test;
 
 import com.pi4j.io.gpio.GpioController;
@@ -59,8 +57,8 @@ public class GpioPinDigitalInputTests {
     private static GpioPinDigitalInput pin;
     private static PinState pinMonitoredState;
 
-    @BeforeClass 
-    public static void setup() {
+    @Before 
+    public void setup() {
         // create a mock gpio provider and controller
         provider = MockGpioFactory.getMockProvider();
         gpio = MockGpioFactory.getInstance();

--- a/pi4j-core/src/test/java/com/pi4j/io/gpio/test/GpioPinDigitalOutputTests.java
+++ b/pi4j-core/src/test/java/com/pi4j/io/gpio/test/GpioPinDigitalOutputTests.java
@@ -28,13 +28,11 @@ package com.pi4j.io.gpio.test;
  * <http://www.gnu.org/licenses/lgpl-3.0.html>.
  * #L%
  */
-
-
 import static org.junit.Assert.*;
 
 import java.util.Collection;
 
-import org.junit.BeforeClass;
+import org.junit.Before;
 import org.junit.Test;
 
 import com.pi4j.io.gpio.GpioController;
@@ -53,8 +51,8 @@ public class GpioPinDigitalOutputTests {
     private static GpioController gpio;
     private static GpioPinDigitalOutput pin;
     
-    @BeforeClass 
-    public static void setup() {
+    @Before
+    public void setup() {
         // create a mock gpio provider and controller
         gpio = MockGpioFactory.getInstance();
         

--- a/pi4j-core/src/test/java/com/pi4j/io/gpio/test/GpioPinPwmOutputTests.java
+++ b/pi4j-core/src/test/java/com/pi4j/io/gpio/test/GpioPinPwmOutputTests.java
@@ -28,14 +28,12 @@ package com.pi4j.io.gpio.test;
  * <http://www.gnu.org/licenses/lgpl-3.0.html>.
  * #L%
  */
-
-
 import static org.junit.Assert.*;
 
 import java.util.Collection;
 import java.util.Random;
 
-import org.junit.BeforeClass;
+import org.junit.Before;
 import org.junit.Test;
 
 import com.pi4j.io.gpio.GpioController;
@@ -54,8 +52,8 @@ public class GpioPinPwmOutputTests {
     private static GpioPinPwmOutput pin;
     private static int initialValue = 2;
     
-    @BeforeClass 
-    public static void setup() {
+    @Before
+    public void setup() {
         // create a mock gpio provider and controller
         gpio = MockGpioFactory.getInstance();
         

--- a/pi4j-core/src/test/java/com/pi4j/io/gpio/trigger/test/GpioCallbackTriggerTests.java
+++ b/pi4j-core/src/test/java/com/pi4j/io/gpio/trigger/test/GpioCallbackTriggerTests.java
@@ -28,14 +28,12 @@ package com.pi4j.io.gpio.trigger.test;
  * <http://www.gnu.org/licenses/lgpl-3.0.html>.
  * #L%
  */
-
-
 import static org.junit.Assert.*;
 
 import java.util.concurrent.Callable;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import com.pi4j.io.gpio.GpioController;
@@ -54,8 +52,8 @@ public class GpioCallbackTriggerTests {
     private static GpioCallbackTrigger trigger;
     private static int callbackCounter = 0;
     
-    @BeforeClass 
-    public static void setup() {
+    @Before 
+    public void setup() {
         // create a mock gpio provider and controller
         provider = MockGpioFactory.getMockProvider();
         gpio = MockGpioFactory.getInstance();
@@ -76,8 +74,8 @@ public class GpioCallbackTriggerTests {
         inputPin.addTrigger(trigger);        
     }
     
-    @AfterClass 
-    public static void teardown() {
+    @After 
+    public void teardown() {
         // remove trigger
         inputPin.removeTrigger(trigger);        
     }    

--- a/pi4j-core/src/test/java/com/pi4j/io/gpio/trigger/test/GpioInverseSyncStateTriggerTests.java
+++ b/pi4j-core/src/test/java/com/pi4j/io/gpio/trigger/test/GpioInverseSyncStateTriggerTests.java
@@ -28,12 +28,10 @@ package com.pi4j.io.gpio.trigger.test;
  * <http://www.gnu.org/licenses/lgpl-3.0.html>.
  * #L%
  */
-
-
 import static org.junit.Assert.*;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import com.pi4j.io.gpio.GpioController;
@@ -53,8 +51,8 @@ public class GpioInverseSyncStateTriggerTests {
     private static GpioPinDigitalOutput outputPin;
     private static GpioInverseSyncStateTrigger trigger;
     
-    @BeforeClass 
-    public static void setup() {
+    @Before 
+    public void setup() {
         // create a mock gpio provider and controller
         provider = MockGpioFactory.getMockProvider();
         gpio = MockGpioFactory.getInstance();
@@ -70,8 +68,8 @@ public class GpioInverseSyncStateTriggerTests {
         inputPin.addTrigger(trigger);        
     }
     
-    @AfterClass 
-    public static void teardown() {
+    @After 
+    public void teardown() {
         // remove trigger
         inputPin.removeTrigger(trigger);        
     }    

--- a/pi4j-core/src/test/java/com/pi4j/io/gpio/trigger/test/GpioPulseStateTriggerTests.java
+++ b/pi4j-core/src/test/java/com/pi4j/io/gpio/trigger/test/GpioPulseStateTriggerTests.java
@@ -28,12 +28,10 @@ package com.pi4j.io.gpio.trigger.test;
  * <http://www.gnu.org/licenses/lgpl-3.0.html>.
  * #L%
  */
-
-
 import static org.junit.Assert.*;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import com.pi4j.io.gpio.GpioController;
@@ -53,8 +51,8 @@ public class GpioPulseStateTriggerTests {
     private static GpioPinDigitalOutput outputPin;
     private static GpioPulseStateTrigger trigger;
     
-    @BeforeClass 
-    public static void setup() {
+    @Before 
+    public void setup() {
         // create a mock gpio provider and controller
         provider = MockGpioFactory.getMockProvider();
         gpio = MockGpioFactory.getInstance();
@@ -70,8 +68,8 @@ public class GpioPulseStateTriggerTests {
         inputPin.addTrigger(trigger);        
     }
     
-    @AfterClass 
-    public static void teardown() {
+    @After 
+    public void teardown() {
         // remove trigger
         inputPin.removeTrigger(trigger);        
     }    

--- a/pi4j-core/src/test/java/com/pi4j/io/gpio/trigger/test/GpioSetStateTriggerTests.java
+++ b/pi4j-core/src/test/java/com/pi4j/io/gpio/trigger/test/GpioSetStateTriggerTests.java
@@ -28,12 +28,10 @@ package com.pi4j.io.gpio.trigger.test;
  * <http://www.gnu.org/licenses/lgpl-3.0.html>.
  * #L%
  */
-
-
 import static org.junit.Assert.*;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import com.pi4j.io.gpio.GpioController;
@@ -54,8 +52,8 @@ public class GpioSetStateTriggerTests {
     private static GpioSetStateTrigger triggerHigh;
     private static GpioSetStateTrigger triggerLow;
     
-    @BeforeClass 
-    public static void setup() {
+    @Before 
+    public void setup() {
         // create a mock gpio provider and controller
         provider = MockGpioFactory.getMockProvider();
         gpio = MockGpioFactory.getInstance();
@@ -73,8 +71,8 @@ public class GpioSetStateTriggerTests {
         inputPin.addTrigger(triggerLow);
     }
     
-    @AfterClass 
-    public static void teardown() {
+    @After 
+    public void teardown() {
         // remove triggers
         inputPin.removeTrigger(triggerHigh);        
         inputPin.removeTrigger(triggerLow);

--- a/pi4j-core/src/test/java/com/pi4j/io/gpio/trigger/test/GpioSyncStateTriggerTests.java
+++ b/pi4j-core/src/test/java/com/pi4j/io/gpio/trigger/test/GpioSyncStateTriggerTests.java
@@ -28,12 +28,10 @@ package com.pi4j.io.gpio.trigger.test;
  * <http://www.gnu.org/licenses/lgpl-3.0.html>.
  * #L%
  */
-
-
 import static org.junit.Assert.*;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import com.pi4j.io.gpio.GpioController;
@@ -53,8 +51,8 @@ public class GpioSyncStateTriggerTests {
     private static GpioPinDigitalOutput outputPin;
     private static GpioSyncStateTrigger trigger;
     
-    @BeforeClass 
-    public static void setup() {
+    @Before 
+    public void setup() {
         // create a mock gpio provider and controller
         provider = MockGpioFactory.getMockProvider();
         gpio = MockGpioFactory.getInstance();
@@ -70,8 +68,8 @@ public class GpioSyncStateTriggerTests {
         inputPin.addTrigger(trigger);        
     }
     
-    @AfterClass 
-    public static void teardown() {
+    @After 
+    public void teardown() {
         // remove trigger
         inputPin.removeTrigger(trigger);        
     }    

--- a/pi4j-core/src/test/java/com/pi4j/io/gpio/trigger/test/GpioToggleStateTriggerTests.java
+++ b/pi4j-core/src/test/java/com/pi4j/io/gpio/trigger/test/GpioToggleStateTriggerTests.java
@@ -28,12 +28,10 @@ package com.pi4j.io.gpio.trigger.test;
  * <http://www.gnu.org/licenses/lgpl-3.0.html>.
  * #L%
  */
-
-
 import static org.junit.Assert.*;
 
-import org.junit.AfterClass;
-import org.junit.BeforeClass;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.Test;
 
 import com.pi4j.io.gpio.GpioController;
@@ -53,8 +51,8 @@ public class GpioToggleStateTriggerTests {
     private static GpioPinDigitalOutput outputPin;
     private static GpioToggleStateTrigger trigger;
     
-    @BeforeClass 
-    public static void setup() {
+    @Before 
+    public void setup() {
         // create a mock gpio provider and controller
         provider = MockGpioFactory.getMockProvider();
         gpio = MockGpioFactory.getInstance();
@@ -70,8 +68,8 @@ public class GpioToggleStateTriggerTests {
         inputPin.addTrigger(trigger);        
     }
     
-    @AfterClass 
-    public static void teardown() {
+    @After 
+    public void teardown() {
         // remove trigger
         inputPin.removeTrigger(trigger);        
     }    

--- a/pi4j-core/src/test/java/com/pi4j/temperature/test/TemperatureConversionTests.java
+++ b/pi4j-core/src/test/java/com/pi4j/temperature/test/TemperatureConversionTests.java
@@ -40,10 +40,6 @@ import com.pi4j.temperature.TemperatureScale;
 
 public class TemperatureConversionTests {
 
-    @BeforeClass 
-    public static void setup() {
-    }
-
     // **********************************************
     // FARENHEIT CONVERSION TESTS
     // **********************************************

--- a/pi4j-core/src/test/java/com/pi4j/util/StringUtilTests.java
+++ b/pi4j-core/src/test/java/com/pi4j/util/StringUtilTests.java
@@ -37,10 +37,6 @@ import org.junit.Test;
 
 public class StringUtilTests {
 
-    @BeforeClass 
-    public static void setup() {
-    }
-
     @Test
     public void testIsNullOrEmpty() {
         assertTrue(StringUtil.isNullOrEmpty(null));


### PR DESCRIPTION
Use @Before instead of @BeforeClass to initialize fixture for
each test.  This eliminates the possibility of a dependency between
@Test methods.
