### PR TITLE
Added rounding mode to fix Arithmetic Exception

### DIFF
--- a/pi4j-device/src/main/java/com/pi4j/component/servo/impl/PCA9685GpioServoDriver.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/servo/impl/PCA9685GpioServoDriver.java
@@ -84,6 +84,6 @@ public class PCA9685GpioServoDriver implements ServoDriver {
     }
     
     protected void updateResolution() {
-        resolution = new BigDecimal(4096).divide(getProvider().getFrequency()).intValue();
+        resolution = new BigDecimal(4096).divide(getProvider().getFrequency(), BigDecimal.ROUND_HALF_DOWN).intValue();
     }
 }


### PR DESCRIPTION
The updateResolution method invokes an Arithmetic Exception:

```
Exception in thread "main" java.lang.ArithmeticException: Non-terminating decimal expansion; no exact representable decimal result.
```

This should fix the error. But I am not sure, since I have not update the .jar dependency file yet. I have some projects using Raspberry Pi and GPIO in mind, and I would love to be able to program in Java. This is my first pull request to this project, and I will continue to contribute. Thanks!
