### PR TITLE
let maven pack a test jar

### DIFF
--- a/pi4j-core/pom.xml
+++ b/pi4j-core/pom.xml
@@ -174,6 +174,13 @@
 						<manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
 					</archive>
 				</configuration>
+				<executions>
+          				<execution>
+            					<goals>
+              						<goal>test-jar</goal>
+            					</goals>
+          				</execution>
+        			</executions>
 			</plugin>
 
 			<!-- OPTIONALLY DEPLOY THE FINAL JAR TO THE RASPBERRY PI -->


### PR DESCRIPTION
This test-jar can be included in the application's pom.xml to use p.ex. the mock classes
