### PR TITLE
Correction of non-standard characters.

### DIFF
--- a/pi4j-core/src/main/java/com/pi4j/io/i2c/I2CBus.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/i2c/I2CBus.java
@@ -39,9 +39,17 @@ import java.io.IOException;
  */
 
 public interface I2CBus {
-
-    public static final int BUS_0 = 0;
-    public static final int BUS_1 = 1;
+    
+    public static final int BUS_0  = 0;
+    public static final int BUS_1  = 1;
+    public static final int BUS_10 = 10;
+    public static final int BUS_11 = 11;
+    public static final int BUS_12 = 12;
+    public static final int BUS_13 = 13;
+    public static final int BUS_14 = 14;
+    public static final int BUS_15 = 15;
+    public static final int BUS_16 = 16;
+    public static final int BUS_17 = 17;
 
     /**
      * Returns i2c device.

--- a/pi4j-core/src/main/java/com/pi4j/io/i2c/impl/I2CBusImpl.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/i2c/impl/I2CBusImpl.java
@@ -52,7 +52,31 @@ public class I2CBusImpl implements I2CBus {
 
     /** Singleton instance of bus 1 */
     private static I2CBus bus1 = null;
-    
+
+    /** Singleton instance of bus 10 */
+    private static I2CBus bus10 = null;
+
+    /** Singleton instance of bus 11 */
+    private static I2CBus bus11 = null;
+
+    /** Singleton instance of bus 12 */
+    private static I2CBus bus12 = null;
+
+    /** Singleton instance of bus 13 */
+    private static I2CBus bus13 = null;
+
+    /** Singleton instance of bus 14 */
+    private static I2CBus bus14 = null;
+
+    /** Singleton instance of bus 15 */
+    private static I2CBus bus15 = null;
+
+    /** Singleton instance of bus 16 */
+    private static I2CBus bus16 = null;
+
+    /** Singleton instance of bus 17 */
+    private static I2CBus bus17 = null;
+
     /** to lock the creation/destruction of the bus singletons */
     private final static Lock lock = new ReentrantLock( true );
 
@@ -66,19 +90,78 @@ public class I2CBusImpl implements I2CBus {
     public static I2CBus getBus(int busNumber) throws IOException {
         I2CBus bus;
         lock.lock();
-        if (busNumber == 0) {
+        switch (busNumber) {
+        case 0:
             bus = bus0;
             if (bus == null) {
-                bus = new I2CBusImpl("/dev/i2c-0");
+                bus = new I2CBusImpl("/dev/i2c-" + busNumber);
                 bus0 = bus;
             }
-        } else if (busNumber == 1) {
+            break;
+        case 1:
             bus = bus1;
             if (bus == null) {
-                bus = new I2CBusImpl("/dev/i2c-1");
+                bus = new I2CBusImpl("/dev/i2c-" + busNumber);
                 bus1 = bus;
             }
-        } else {
+            break;
+        case 10:
+            bus = bus10;
+            if (bus == null) {
+                bus = new I2CBusImpl("/dev/i2c-" + busNumber);
+                bus10 = bus;
+            }
+            break;
+        case 11:
+            bus = bus11;
+            if (bus == null) {
+                bus = new I2CBusImpl("/dev/i2c-" + busNumber);
+                bus11 = bus;
+            }
+            break;
+        case 12:
+            bus = bus12;
+            if (bus == null) {
+                bus = new I2CBusImpl("/dev/i2c-" + busNumber);
+                bus12 = bus;
+            }
+            break;
+        case 13:
+            bus = bus13;
+            if (bus == null) {
+                bus = new I2CBusImpl("/dev/i2c-" + busNumber);
+                bus13 = bus;
+            }
+            break;
+        case 14:
+            bus = bus14;
+            if (bus == null) {
+                bus = new I2CBusImpl("/dev/i2c-" + busNumber);
+                bus14 = bus;
+            }
+            break;
+        case 15:
+            bus = bus15;
+            if (bus == null) {
+                bus = new I2CBusImpl("/dev/i2c-" + busNumber);
+                bus15 = bus;
+            }
+            break;
+        case 16:
+            bus = bus16;
+            if (bus == null) {
+                bus = new I2CBusImpl("/dev/i2c-" + busNumber);
+                bus16 = bus;
+            }
+            break;
+        case 17:
+            bus = bus17;
+            if (bus == null) {
+                bus = new I2CBusImpl("/dev/i2c-" + busNumber);
+                bus17 = bus;
+            }
+            break;
+        default:
             throw new IOException("Unknown bus number " + busNumber);
         }
         lock.unlock();
@@ -136,6 +219,22 @@ public class I2CBusImpl implements I2CBus {
             bus0 = null;
         } else if (this == bus1) {
             bus1 = null;
+        } else if (this == bus10) {
+            bus10 = null;
+        } else if (this == bus11) {
+            bus11 = null;
+        } else if (this == bus12) {
+            bus12 = null;
+        } else if (this == bus13) {
+            bus13 = null;
+        } else if (this == bus14) {
+            bus14 = null;
+        } else if (this == bus15) {
+            bus15 = null;
+        } else if (this == bus16) {
+            bus16 = null;
+        } else if (this == bus17) {
+            bus17 = null;
         }
         lock.unlock();
     }

--- a/pi4j-core/src/main/java/com/pi4j/wiringpi/Gpio.java
+++ b/pi4j-core/src/main/java/com/pi4j/wiringpi/Gpio.java
@@ -497,7 +497,7 @@ public class Gpio {
      * 32-bit integer microseconds or approximately 71 minutes.
      *
      * Delays under 100 microseconds are timed using a hard-coded loop continually polling the system time,
-     * Delays over 100 microseconds are done using the system nanosleep() function – You may need to consider
+     * Delays over 100 microseconds are done using the system nanosleep() function - You may need to consider
      * the implications of very short delays on the overall performance of the system, especially if using
      * threads.
      * </p>
@@ -574,7 +574,7 @@ public class Gpio {
      * 
      * </p>
      *
-     * @deprecated Note: Jan 2013: The waitForInterrupt() function is deprecated – you should use the newer
+     * @deprecated Note: Jan 2013: The waitForInterrupt() function is deprecated - you should use the newer
      *             and easier to use wiringPiISR() function.
      *
      * @see <a
@@ -595,14 +595,14 @@ public class Gpio {
      * <p>
      * This function registers a function to received interrupts on the specified pin. The edgeType parameter is either
      * INT_EDGE_FALLING, INT_EDGE_RISING, INT_EDGE_BOTH or INT_EDGE_SETUP. If it is INT_EDGE_SETUP then no
-     * initialisation of the pin will happen – it’s assumed that you have already setup the pin elsewhere
+     * initialisation of the pin will happen - it's assumed that you have already setup the pin elsewhere
      * (e.g. with the gpio program), but if you specify one of the other types, then the pin will be exported and
      * initialised as specified. This is accomplished via a suitable call to the gpio utility program, so it need to
      * be available
      * </p>
      *
      * <p>
-     * The pin number is supplied in the current mode – native wiringPi, BCM_GPIO, physical or Sys modes.
+     * The pin number is supplied in the current mode - native wiringPi, BCM_GPIO, physical or Sys modes.
      * </p>
      *
      * <p>
@@ -610,8 +610,8 @@ public class Gpio {
      * </p>
      *
      * <p>
-     * The function will be called when the interrupt triggers. When it is triggered, it’s cleared in the dispatcher
-     * before calling your function, so if a subsequent interrupt fires before you finish your handler, then it won’t
+     * The function will be called when the interrupt triggers. When it is triggered, it's cleared in the dispatcher
+     * before calling your function, so if a subsequent interrupt fires before you finish your handler, then it won't
      * be missed. (However it can only track one more interrupt, if more than one interrupt fires while one is being
      * handled then they will be ignored)
      * </p>
@@ -694,8 +694,8 @@ public class Gpio {
 
 
     /**
-     * <p> This writes the 8-bit byte supplied to the first 8 GPIO pins. It’s the fastest way to set all 8 bits at once to a particular value,
-     *     although it still takes two write operations to the Pi’s GPIO hardware.  </p>
+     * <p> This writes the 8-bit byte supplied to the first 8 GPIO pins. It's the fastest way to set all 8 bits at once to a particular value,
+     *     although it still takes two write operations to the Pi's GPIO hardware.  </p>
      *
      * @see <a
      *      href="http://wiringpi.com/reference/raspberry-pi-specifics/">http://wiringpi.com/reference/raspberry-pi-specifics/</a>
@@ -706,8 +706,8 @@ public class Gpio {
     /**
      * <p>[PWM]</p>
      *
-     * <p> The PWM generator can run in 2 modes – “balanced” and “mark:space”. The mark:space mode is traditional, however
-     *     the default mode in the Pi is “balanced”. You can switch modes by supplying the parameter: PWM_MODE_BAL or PWM_MODE_MS.</p>
+     * <p> The PWM generator can run in 2 modes - "balanced" and "mark:space". The mark:space mode is traditional, however
+     *     the default mode in the Pi is "balanced". You can switch modes by supplying the parameter: PWM_MODE_BAL or PWM_MODE_MS.</p>
      *
      * @see <a
      *      href="http://wiringpi.com/reference/raspberry-pi-specifics/">http://wiringpi.com/reference/raspberry-pi-specifics/</a>
@@ -740,7 +740,7 @@ public class Gpio {
     /**
      * <p>[Hardware]</p>
      *
-     * <p> This sets the “strength” of the pad drivers for a particular group of pins. There are 3 groups of pins and the drive strength is from 0 to 7. Do not use this unless you know what you are doing. </p>
+     * <p> This sets the "strength" of the pad drivers for a particular group of pins. There are 3 groups of pins and the drive strength is from 0 to 7. Do not use this unless you know what you are doing. </p>
      *
      * @see <a
      *      href="http://wiringpi.com/reference/raspberry-pi-specifics/">http://wiringpi.com/reference/raspberry-pi-specifics/</a>
@@ -762,7 +762,7 @@ public class Gpio {
     /**
      * <p>[Hardware]</p>
      *
-     * <p> This sets the “frequency” of a GPIO pin </p>
+     * <p> This sets the "frequency" of a GPIO pin </p>
      *
      * @see <a
      *      href="http://wiringpi.com/reference/raspberry-pi-specifics/">http://wiringpi.com/reference/raspberry-pi-specifics/</a>


### PR DESCRIPTION
Current file Gpio.java contains characters that are not processed well
by the javadoc generator during the maven compilation process.
Double-quotes (both backward and forward quotes), single-quotes and
hypens are causing compilation issues.
All those characters are changed into their standard counterparts,
resolving the compilation crashes.
