### PR TITLE
unlock if an IOException occurs

### DIFF
--- a/pi4j-core/src/main/java/com/pi4j/io/i2c/impl/I2CBusImpl.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/i2c/impl/I2CBusImpl.java
@@ -39,9 +39,9 @@ import java.util.concurrent.locks.ReentrantLock;
 
 /**
  * This is implementation of i2c bus. This class keeps underlying linux file descriptor of
- * particular bus. As all reads and writes from/to i2c bus are blocked I/Os current implementation uses only 
+ * particular bus. As all reads and writes from/to i2c bus are blocked I/Os current implementation uses only
  * one file per bus for all devices. Device implementations use this class file handle.
- * 
+ *
  * @author Daniel Sendula
  *
  */
@@ -52,13 +52,13 @@ public class I2CBusImpl implements I2CBus {
 
     /** Singleton instance of bus 1 */
     private static I2CBus bus1 = null;
-    
+
     /** to lock the creation/destruction of the bus singletons */
     private final static Lock lock = new ReentrantLock( true );
 
-    /** 
+    /**
      * Factory method that returns bus implementation.
-     * 
+     *
      * @param busNumber bus number
      * @return appropriate bus implementation
      * @throws IOException thrown in case there is a problem opening bus file or bus number is not 0 or 1.
@@ -66,36 +66,41 @@ public class I2CBusImpl implements I2CBus {
     public static I2CBus getBus(int busNumber) throws IOException {
         I2CBus bus;
         lock.lock();
-        if (busNumber == 0) {
-            bus = bus0;
-            if (bus == null) {
-                bus = new I2CBusImpl("/dev/i2c-0");
-                bus0 = bus;
+        try {
+            if (busNumber == 0) {
+                bus = bus0;
+                if (bus == null) {
+                    bus = new I2CBusImpl("/dev/i2c-0");
+                    bus0 = bus;
+                }
+            } else if (busNumber == 1) {
+                bus = bus1;
+                if (bus == null) {
+                    bus = new I2CBusImpl("/dev/i2c-1");
+                    bus1 = bus;
+                }
+            } else {
+                throw new IOException("Unknown bus number " + busNumber);
             }
-        } else if (busNumber == 1) {
-            bus = bus1;
-            if (bus == null) {
-                bus = new I2CBusImpl("/dev/i2c-1");
-                bus1 = bus;
-            }
-        } else {
-            throw new IOException("Unknown bus number " + busNumber);
+        } catch(IOException e) {
+            throw e;
+        } finally {
+            lock.unlock();
         }
-        lock.unlock();
         return bus;
     }
 
     /** File handle for this i2c bus */
     protected int fd;
-    
+
     /** File name of this i2c bus */
     protected String filename;
-    
+
     /**
      * Constructor of i2c bus implementation.
-     * 
+     *
      * @param filename file name of device to be opened.
-     * 
+     *
      * @throws IOException thrown in case that file cannot be opened
      */
     public I2CBusImpl(String filename) throws IOException {
@@ -108,11 +113,11 @@ public class I2CBusImpl implements I2CBus {
 
     /**
      * Returns i2c device implementation ({@link I2CDeviceImpl}).
-     * 
+     *
      * @param address address of i2c device
-     * 
+     *
      * @return implementation of i2c device with given address
-     * 
+     *
      * @throws IOException never in this implementation
      */
     @Override
@@ -122,7 +127,7 @@ public class I2CBusImpl implements I2CBus {
 
     /**
      * Closes this i2c bus
-     * 
+     *
      * @throws IOException never in this implementation
      */
     @Override


### PR DESCRIPTION
bugfix: the lock will never be unlocked if an IOException is thrown
