### PR TITLE
I2c cleanup2

### DIFF
--- a/pi4j-core/src/main/java/com/pi4j/io/i2c/I2CFactory.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/i2c/I2CFactory.java
@@ -69,8 +69,8 @@ public class I2CFactory {
      * @return Return a new I2CBus instance
      * @throws UnsupportedBusNumberException If the given bus-number is not supported by the underlying system
      * @throws IOException If communication to i2c-bus fails
-     * @see I2CProvider#DEFAULT_LOCKAQUIRE_TIMEOUT
-     * @see I2CProvider#DEFAULT_LOCKAQUIRE_TIMEOUT_UNITS
+     * @see I2CFactory#DEFAULT_LOCKAQUIRE_TIMEOUT
+     * @see I2CFactory#DEFAULT_LOCKAQUIRE_TIMEOUT_UNITS
      */
     public static I2CBus getInstance(int busNumber) throws UnsupportedBusNumberException, IOException {
         return provider.getBus(busNumber, DEFAULT_LOCKAQUIRE_TIMEOUT, DEFAULT_LOCKAQUIRE_TIMEOUT_UNITS);

--- a/pi4j-core/src/main/java/com/pi4j/io/i2c/I2CIOException.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/i2c/I2CIOException.java
@@ -1,0 +1,54 @@
+package com.pi4j.io.i2c;
+
+import com.pi4j.jni.I2C;
+
+import java.io.IOException;
+
+public class I2CIOException extends IOException {
+    int rawCode;
+    String baseMessage;
+
+    /**
+     * @param message Exception message
+     * @param rawCode negative POSIX error code with pi4j offsets
+     */
+    public I2CIOException(String message, int rawCode) {
+        super(message);
+
+        this.rawCode = Math.abs(rawCode);
+    }
+
+    /**
+     * Gets the POSIX code associated with this IO error
+     *
+     * @return POSIX error code
+     */
+    public int getCode() {
+        return rawCode - getType() * 10000;
+    }
+
+    /**
+     * @return true if is ioctl error
+     */
+    public boolean isIOCTL() {
+        return getType() == 1;
+    }
+
+    /**
+     * @return true if is write error
+     */
+    public boolean isWrite() {
+        return getType() == 2;
+    }
+
+    /**
+     * @return true if is read error
+     */
+    public boolean isRead() {
+        return getType() == 3;
+    }
+
+    private int getType() {
+        return rawCode / 10000;
+    }
+}

--- a/pi4j-core/src/main/java/com/pi4j/io/i2c/impl/I2CBusImpl.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/i2c/impl/I2CBusImpl.java
@@ -151,6 +151,20 @@ public class I2CBusImpl implements I2CBus {
         close();
     }
 
+    protected void validateBufferOffsets(final byte[] data, final int offset, final int size) {
+        if(offset < 0)
+            throw new IllegalArgumentException("offset must be non-negative");
+
+        if(size < 0)
+            throw new IllegalArgumentException("size must be non-negative");
+
+        if(data == null)
+            throw new IllegalArgumentException("must provide data buffer!");
+
+        if((offset + size) > data.length)
+            throw new IndexOutOfBoundsException("buffer overrun");
+    }
+
     /**
      * Selects the slave device if not already selected on this bus
      *
@@ -184,6 +198,7 @@ public class I2CBusImpl implements I2CBus {
 
     public int readBytesDirect(final I2CDeviceImpl device, final int size, final int offset, final byte[] buffer) throws IOException {
         testForProperOperationConditions(device);
+        validateBufferOffsets(buffer, offset, size);
 
         return runActionOnExclusivLockedBus(() -> {
             int selectResponse = checkSlaveSelect(device);
@@ -212,6 +227,7 @@ public class I2CBusImpl implements I2CBus {
 
     public int readBytes(final I2CDeviceImpl device, final int localAddress, final int size, final int offset, final byte[] buffer) throws IOException {
         testForProperOperationConditions(device);
+        validateBufferOffsets(buffer, offset, size);
 
         return runActionOnExclusivLockedBus(() -> {
             int selectResponse = checkSlaveSelect(device);
@@ -240,6 +256,7 @@ public class I2CBusImpl implements I2CBus {
 
     public int writeBytesDirect(final I2CDeviceImpl device, final int size, final int offset, final byte[] buffer) throws IOException {
         testForProperOperationConditions(device);
+        validateBufferOffsets(buffer, offset, size);
 
         return runActionOnExclusivLockedBus(() -> {
             int selectResponse = checkSlaveSelect(device);
@@ -268,6 +285,7 @@ public class I2CBusImpl implements I2CBus {
 
     public int writeBytes(final I2CDeviceImpl device, final int localAddress, final int size, final int offset, final byte[] buffer) throws IOException {
         testForProperOperationConditions(device);
+        validateBufferOffsets(buffer, offset, size);
 
         return runActionOnExclusivLockedBus(() -> {
             int selectResponse = checkSlaveSelect(device);
@@ -282,6 +300,8 @@ public class I2CBusImpl implements I2CBus {
 
     public int writeAndReadBytesDirect(final I2CDeviceImpl device, final int writeSize, final int writeOffset, final byte[] writeBuffer, final int readSize, final int readOffset, final byte[] readBuffer) throws IOException {
         testForProperOperationConditions(device);
+        validateBufferOffsets(writeBuffer, writeOffset, writeSize);
+        validateBufferOffsets(readBuffer, readOffset, readSize);
 
         return runActionOnExclusivLockedBus(() -> {
             int selectResponse = checkSlaveSelect(device);

--- a/pi4j-core/src/main/java/com/pi4j/io/i2c/impl/I2CBusImpl.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/i2c/impl/I2CBusImpl.java
@@ -131,117 +131,92 @@ public class I2CBusImpl implements I2CBus {
      */
     @Override
     public void close() throws IOException {
-        if (fd == -1) {
-            return;
-        }
-
-        I2CProviderImpl.closeBus(getBusNumber(), lockAquireTimeout, lockAquireTimeoutUnit, new Callable<Void>() {
-            @Override
-            public Void call() {
-                I2C.i2cClose(fd);
-                fd = -1;
+        runActionOnExclusivLockedBus(() -> {
+            if (fd == -1) {
                 return null;
             }
+
+            I2C.i2cClose(fd);
+            fd = -1;
+            return null;
         });
+    }
+
+    @Override
+    protected void finalize() throws Throwable {
+        close();
     }
 
     public int readByteDirect(final I2CDeviceImpl device) throws IOException {
         testForProperOperationConditions(device);
 
-        return runActionOnExclusivLockedBus(new Callable<Integer>() {
-            @Override
-            public Integer call() throws Exception {
-                return I2C.i2cReadByteDirect(fd, device.getAddress());
-            }
-        });
+        return runActionOnExclusivLockedBus(() ->
+            I2C.i2cReadByteDirect(fd, device.getAddress())
+        );
     }
 
     public int readBytesDirect(final I2CDeviceImpl device, final int size, final int offset, final byte[] buffer) throws IOException {
         testForProperOperationConditions(device);
 
-        return runActionOnExclusivLockedBus(new Callable<Integer>() {
-            @Override
-            public Integer call() throws Exception {
-                return I2C.i2cReadBytesDirect(fd, device.getAddress(), size, offset, buffer);
-            }
-        });
+        return runActionOnExclusivLockedBus(() ->
+            I2C.i2cReadBytesDirect(fd, device.getAddress(), size, offset, buffer)
+        );
     }
 
     public int readByte(final I2CDeviceImpl device, final int localAddress) throws IOException {
         testForProperOperationConditions(device);
 
-        return runActionOnExclusivLockedBus(new Callable<Integer>() {
-            @Override
-            public Integer call() throws Exception {
-                return I2C.i2cReadByte(fd, device.getAddress(), localAddress);
-            }
-        });
+        return runActionOnExclusivLockedBus(() ->
+            I2C.i2cReadByte(fd, device.getAddress(), localAddress)
+        );
     }
 
     public int readBytes(final I2CDeviceImpl device, final int localAddress, final int size, final int offset, final byte[] buffer) throws IOException {
         testForProperOperationConditions(device);
 
-        return runActionOnExclusivLockedBus(new Callable<Integer>() {
-            @Override
-            public Integer call() throws Exception {
-                return I2C.i2cReadBytes(fd, device.getAddress(), localAddress, size, offset, buffer);
-            }
-        });
+        return runActionOnExclusivLockedBus(() ->
+            I2C.i2cReadBytes(fd, device.getAddress(), localAddress, size, offset, buffer)
+        );
     }
 
     public int writeByteDirect(final I2CDeviceImpl device, final byte data) throws IOException {
         testForProperOperationConditions(device);
 
-        return runActionOnExclusivLockedBus(new Callable<Integer>() {
-            @Override
-            public Integer call() throws Exception {
-                return I2C.i2cWriteByteDirect(fd, device.getAddress(), data);
-            }
-        });
+        return runActionOnExclusivLockedBus(() ->
+            I2C.i2cWriteByteDirect(fd, device.getAddress(), data)
+        );
     }
 
     public int writeBytesDirect(final I2CDeviceImpl device, final int size, final int offset, final byte[] buffer) throws IOException {
         testForProperOperationConditions(device);
 
-        return runActionOnExclusivLockedBus(new Callable<Integer>() {
-            @Override
-            public Integer call() throws Exception {
-                return I2C.i2cWriteBytesDirect(fd, device.getAddress(), size, offset, buffer);
-            }
-        });
+        return runActionOnExclusivLockedBus(() ->
+            I2C.i2cWriteBytesDirect(fd, device.getAddress(), size, offset, buffer)
+        );
     }
 
     public int writeByte(final I2CDeviceImpl device, final int localAddress, final byte data) throws IOException {
         testForProperOperationConditions(device);
 
-        return runActionOnExclusivLockedBus(new Callable<Integer>() {
-            @Override
-            public Integer call() throws Exception {
-                return I2C.i2cWriteByte(fd, device.getAddress(), localAddress, data);
-            }
-        });
+        return runActionOnExclusivLockedBus(() ->
+            I2C.i2cWriteByte(fd, device.getAddress(), localAddress, data)
+        );
     }
 
     public int writeBytes(final I2CDeviceImpl device, final int localAddress, final int size, final int offset, final byte[] buffer) throws IOException {
         testForProperOperationConditions(device);
 
-        return runActionOnExclusivLockedBus(new Callable<Integer>() {
-            @Override
-            public Integer call() throws Exception {
-                return I2C.i2cWriteBytes(fd, device.getAddress(), localAddress, size, offset, buffer);
-            }
-        });
+        return runActionOnExclusivLockedBus(() ->
+            I2C.i2cWriteBytes(fd, device.getAddress(), localAddress, size, offset, buffer)
+        );
     }
 
     public int writeAndReadBytesDirect(final I2CDeviceImpl device, final int writeSize, final int writeOffset, final byte[] writeBuffer, final int readSize, final int readOffset, final byte[] readBuffer) throws IOException {
         testForProperOperationConditions(device);
 
-        return runActionOnExclusivLockedBus(new Callable<Integer>() {
-            @Override
-            public Integer call() throws Exception {
-                return I2C.i2cWriteAndReadBytes(fd, device.getAddress(), writeSize, writeOffset, writeBuffer, readSize, readOffset, readBuffer);
-            }
-        });
+        return runActionOnExclusivLockedBus(() ->
+            I2C.i2cWriteAndReadBytes(fd, device.getAddress(), writeSize, writeOffset, writeBuffer, readSize, readOffset, readBuffer)
+        );
     }
 
     /**
@@ -274,7 +249,7 @@ public class I2CBusImpl implements I2CBus {
             }
         } catch (InterruptedException e) {
             logger.log(Level.FINER, "Failed locking I2CBusImpl-" + busNumber, e);
-            throw new RuntimeException("Could not abtain an access-lock!", e);
+            throw new RuntimeException("Could not obtain an access-lock!", e);
         } catch (IOException e) { // unwrap IOExceptionWrapperException
             throw e;
         } catch (RuntimeException e) {
@@ -282,7 +257,7 @@ public class I2CBusImpl implements I2CBus {
         } catch (Exception e) { // unexpected exceptions
             throw new RuntimeException(e);
         }
-        throw new RuntimeException("Could not abtain an access-lock!");
+        throw new RuntimeException("Could not obtain an access-lock!");
     }
 
     private void testForProperOperationConditions(final I2CDeviceImpl device) throws IOException {

--- a/pi4j-core/src/main/java/com/pi4j/io/i2c/impl/I2CBusImpl.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/i2c/impl/I2CBusImpl.java
@@ -58,6 +58,8 @@ public class I2CBusImpl implements I2CBus {
     /** File handle for this i2c bus */
     protected int fd = -1;
 
+    protected int lastAddress = -1;
+
     /** File name of this i2c bus */
     protected String filename;
 
@@ -122,6 +124,8 @@ public class I2CBusImpl implements I2CBus {
         if (fd < 0) {
             throw new IOException("Cannot open file handle for " + filename + " got " + fd + " back.");
         }
+
+        lastAddress = -1;
     }
 
     /**
@@ -145,13 +149,36 @@ public class I2CBusImpl implements I2CBus {
         });
     }
 
+    /**
+     * Selects the slave device if not already selected on this bus
+     *
+     * @param device device to select
+     * @return 0 if success or else (-errno - 10000)
+     */
+    private int checkSlaveSelect(final I2CDeviceImpl device) {
+        int addr = device.getAddress();
+
+        if(lastAddress != addr) {
+            lastAddress = addr;
+            return I2C.i2cSlaveSelect(fd, addr);
+        }
+
+        return 0;
+    }
+
     public int readByteDirect(final I2CDeviceImpl device) throws IOException {
         testForProperOperationConditions(device);
 
         return runActionOnExclusivLockedBus(new Callable<Integer>() {
             @Override
             public Integer call() throws Exception {
-                return I2C.i2cReadByteDirect(fd, device.getAddress());
+                int selectResponse = checkSlaveSelect(device);
+
+                if(selectResponse < 0) {
+                    return selectResponse;
+                }
+
+                return I2C.i2cReadByteDirect(fd);
             }
         });
     }
@@ -162,7 +189,13 @@ public class I2CBusImpl implements I2CBus {
         return runActionOnExclusivLockedBus(new Callable<Integer>() {
             @Override
             public Integer call() throws Exception {
-                return I2C.i2cReadBytesDirect(fd, device.getAddress(), size, offset, buffer);
+                int selectResponse = checkSlaveSelect(device);
+
+                if(selectResponse < 0) {
+                    return selectResponse;
+                }
+
+                return I2C.i2cReadBytesDirect(fd, size, offset, buffer);
             }
         });
     }
@@ -173,7 +206,13 @@ public class I2CBusImpl implements I2CBus {
         return runActionOnExclusivLockedBus(new Callable<Integer>() {
             @Override
             public Integer call() throws Exception {
-                return I2C.i2cReadByte(fd, device.getAddress(), localAddress);
+                int selectResponse = checkSlaveSelect(device);
+
+                if(selectResponse < 0) {
+                    return selectResponse;
+                }
+
+                return I2C.i2cReadByte(fd, localAddress);
             }
         });
     }
@@ -184,7 +223,13 @@ public class I2CBusImpl implements I2CBus {
         return runActionOnExclusivLockedBus(new Callable<Integer>() {
             @Override
             public Integer call() throws Exception {
-                return I2C.i2cReadBytes(fd, device.getAddress(), localAddress, size, offset, buffer);
+                int selectResponse = checkSlaveSelect(device);
+
+                if(selectResponse < 0) {
+                    return selectResponse;
+                }
+
+                return I2C.i2cReadBytes(fd, localAddress, size, offset, buffer);
             }
         });
     }
@@ -195,7 +240,13 @@ public class I2CBusImpl implements I2CBus {
         return runActionOnExclusivLockedBus(new Callable<Integer>() {
             @Override
             public Integer call() throws Exception {
-                return I2C.i2cWriteByteDirect(fd, device.getAddress(), data);
+                int selectResponse = checkSlaveSelect(device);
+
+                if(selectResponse < 0) {
+                    return selectResponse;
+                }
+
+                return I2C.i2cWriteByteDirect(fd, data);
             }
         });
     }
@@ -206,7 +257,13 @@ public class I2CBusImpl implements I2CBus {
         return runActionOnExclusivLockedBus(new Callable<Integer>() {
             @Override
             public Integer call() throws Exception {
-                return I2C.i2cWriteBytesDirect(fd, device.getAddress(), size, offset, buffer);
+                int selectResponse = checkSlaveSelect(device);
+
+                if(selectResponse < 0) {
+                    return selectResponse;
+                }
+
+                return I2C.i2cWriteBytesDirect(fd, size, offset, buffer);
             }
         });
     }
@@ -217,7 +274,13 @@ public class I2CBusImpl implements I2CBus {
         return runActionOnExclusivLockedBus(new Callable<Integer>() {
             @Override
             public Integer call() throws Exception {
-                return I2C.i2cWriteByte(fd, device.getAddress(), localAddress, data);
+                int selectResponse = checkSlaveSelect(device);
+
+                if(selectResponse < 0) {
+                    return selectResponse;
+                }
+
+                return I2C.i2cWriteByte(fd, localAddress, data);
             }
         });
     }
@@ -228,7 +291,13 @@ public class I2CBusImpl implements I2CBus {
         return runActionOnExclusivLockedBus(new Callable<Integer>() {
             @Override
             public Integer call() throws Exception {
-                return I2C.i2cWriteBytes(fd, device.getAddress(), localAddress, size, offset, buffer);
+                int selectResponse = checkSlaveSelect(device);
+
+                if(selectResponse < 0) {
+                    return selectResponse;
+                }
+
+                return I2C.i2cWriteBytes(fd, localAddress, size, offset, buffer);
             }
         });
     }
@@ -239,7 +308,13 @@ public class I2CBusImpl implements I2CBus {
         return runActionOnExclusivLockedBus(new Callable<Integer>() {
             @Override
             public Integer call() throws Exception {
-                return I2C.i2cWriteAndReadBytes(fd, device.getAddress(), writeSize, writeOffset, writeBuffer, readSize, readOffset, readBuffer);
+                int selectResponse = checkSlaveSelect(device);
+
+                if(selectResponse < 0) {
+                    return selectResponse;
+                }
+
+                return I2C.i2cWriteAndReadBytes(fd, writeSize, writeOffset, writeBuffer, readSize, readOffset, readBuffer);
             }
         });
     }

--- a/pi4j-core/src/main/java/com/pi4j/io/i2c/impl/I2CDeviceImpl.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/i2c/impl/I2CDeviceImpl.java
@@ -32,6 +32,7 @@ package com.pi4j.io.i2c.impl;
 import java.io.IOException;
 
 import com.pi4j.io.i2c.I2CDevice;
+import com.pi4j.io.i2c.I2CIOException;
 
 /**
  * Implementation of i2c device. This class only holds reference to i2c bus (so it can use its handle) and device address.
@@ -40,7 +41,6 @@ import com.pi4j.io.i2c.I2CDevice;
  *
  */
 public class I2CDeviceImpl implements I2CDevice {
-
     /**
      * Reference to i2c bus
      */
@@ -90,7 +90,7 @@ public class I2CDeviceImpl implements I2CDevice {
     public void write(final byte data) throws IOException {
         int ret = getBus().writeByteDirect(this, data);
         if (ret < 0) {
-            throw new IOException("Error writing to " + makeDescription() + ". Got '" + ret + "'.");
+            throw new I2CIOException("Error writing to " + makeDescription() + ". Got '" + ret + "'.", ret);
 
         }
     }
@@ -106,9 +106,12 @@ public class I2CDeviceImpl implements I2CDevice {
      */
     @Override
     public void write(final byte[] data, final int offset, final int size) throws IOException {
+        if((offset + size) > data.length)
+            throw new IndexOutOfBoundsException("buffer overrun");
+
         int ret = getBus().writeBytesDirect(this, size, offset, data);
         if (ret < 0) {
-            throw new IOException("Error writing to " + makeDescription() + ". Got '" + ret + "'.");
+            throw new I2CIOException("Error writing to " + makeDescription() + ". Got '" + ret + "'.", ret);
         }
     }
 
@@ -136,7 +139,7 @@ public class I2CDeviceImpl implements I2CDevice {
     public void write(final int address, final byte data) throws IOException {
         int ret = getBus().writeByte(this, address, data);
         if (ret < 0) {
-            throw new IOException("Error writing to " + makeDescription(address) + ". Got '" + ret + "'.");
+            throw new I2CIOException("Error writing to " + makeDescription(address) + ". Got '" + ret + "'.", ret);
         }
     }
 
@@ -152,9 +155,12 @@ public class I2CDeviceImpl implements I2CDevice {
      */
     @Override
     public void write(final int address, final byte[] data, final int offset, final int size) throws IOException {
+        if((offset + size) > data.length)
+            throw new IndexOutOfBoundsException("buffer overrun");
+
         int ret = getBus().writeBytes(this, address, size, offset, data);
         if (ret < 0) {
-            throw new IOException("Error writing to " + makeDescription(address) + ". Got '" + ret + "'.");
+            throw new I2CIOException("Error writing to " + makeDescription(address) + ". Got '" + ret + "'.", ret);
         }
     }
 
@@ -181,7 +187,7 @@ public class I2CDeviceImpl implements I2CDevice {
     public int read() throws IOException {
         int ret = getBus().readByteDirect(this);
         if (ret < 0) {
-            throw new IOException("Error reading from " + makeDescription() + ". Got '" + ret + "'.");
+            throw new I2CIOException("Error reading from " + makeDescription() + ". Got '" + ret + "'.", ret);
         }
         return ret;
     }
@@ -205,9 +211,12 @@ public class I2CDeviceImpl implements I2CDevice {
      */
     @Override
     public int read(final byte[] data, final int offset, final int size) throws IOException {
+        if((offset + size) > data.length)
+            throw new IndexOutOfBoundsException("buffer overrun");
+
         int ret = getBus().readBytesDirect(this, size, offset, data);
         if (ret < 0) {
-            throw new IOException("Error reading from " + makeDescription() + ". Got '" + ret + "'.");
+            throw new I2CIOException("Error reading from " + makeDescription() + ". Got '" + ret + "'.", ret);
         }
         return ret;
     }
@@ -224,7 +233,7 @@ public class I2CDeviceImpl implements I2CDevice {
     public int read(final int address) throws IOException {
         int ret = getBus().readByte(this, address);
         if (ret < 0) {
-            throw new IOException("Error reading from " + makeDescription(address) + ". Got '" + ret + "'.");
+            throw new I2CIOException("Error reading from " + makeDescription(address) + ". Got '" + ret + "'.", ret);
         }
         return ret;
     }
@@ -249,9 +258,12 @@ public class I2CDeviceImpl implements I2CDevice {
      */
     @Override
     public int read(final int address, final byte[] data, final int offset, final int size) throws IOException {
+        if((offset + size) > data.length)
+            throw new IndexOutOfBoundsException("buffer overrun");
+
         int ret = getBus().readBytes(this, address, size, offset, data);
         if (ret < 0) {
-            throw new IOException("Error reading from " + makeDescription(address) + ". Got '" + ret + "'.");
+            throw new I2CIOException("Error reading from " + makeDescription(address) + ". Got '" + ret + "'.", ret);
         }
         return ret;
     }
@@ -272,9 +284,15 @@ public class I2CDeviceImpl implements I2CDevice {
      */
     @Override
     public int read(final byte[] writeData, final int writeOffset, final int writeSize, final byte[] readData, final int readOffset, final int readSize) throws IOException {
+        if((readOffset + readSize) > readData.length)
+            throw new IndexOutOfBoundsException("read buffer overrun");
+
+        if((writeOffset + writeSize) > writeData.length)
+            throw new IndexOutOfBoundsException("write buffer overrun");
+
         int ret = getBus().writeAndReadBytesDirect(this, writeSize, writeOffset, writeData, readSize, readOffset, readData);
         if (ret < 0) {
-            throw new IOException("Error reading from " + makeDescription() + ". Got '" + ret + "'.");
+            throw new I2CIOException("Error reading from " + makeDescription() + ". Got '" + ret + "'.", ret);
         }
         return ret;
     }

--- a/pi4j-core/src/main/java/com/pi4j/io/i2c/impl/I2CDeviceImpl.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/i2c/impl/I2CDeviceImpl.java
@@ -106,9 +106,6 @@ public class I2CDeviceImpl implements I2CDevice {
      */
     @Override
     public void write(final byte[] data, final int offset, final int size) throws IOException {
-        if((offset + size) > data.length)
-            throw new IndexOutOfBoundsException("buffer overrun");
-
         int ret = getBus().writeBytesDirect(this, size, offset, data);
         if (ret < 0) {
             throw new I2CIOException("Error writing to " + makeDescription() + ". Got '" + ret + "'.", ret);
@@ -155,9 +152,6 @@ public class I2CDeviceImpl implements I2CDevice {
      */
     @Override
     public void write(final int address, final byte[] data, final int offset, final int size) throws IOException {
-        if((offset + size) > data.length)
-            throw new IndexOutOfBoundsException("buffer overrun");
-
         int ret = getBus().writeBytes(this, address, size, offset, data);
         if (ret < 0) {
             throw new I2CIOException("Error writing to " + makeDescription(address) + ". Got '" + ret + "'.", ret);
@@ -192,6 +186,8 @@ public class I2CDeviceImpl implements I2CDevice {
         return ret;
     }
 
+
+
     /**
      * <p>
      * This method reads bytes from the i2c device to given buffer at asked offset.
@@ -211,9 +207,6 @@ public class I2CDeviceImpl implements I2CDevice {
      */
     @Override
     public int read(final byte[] data, final int offset, final int size) throws IOException {
-        if((offset + size) > data.length)
-            throw new IndexOutOfBoundsException("buffer overrun");
-
         int ret = getBus().readBytesDirect(this, size, offset, data);
         if (ret < 0) {
             throw new I2CIOException("Error reading from " + makeDescription() + ". Got '" + ret + "'.", ret);
@@ -258,9 +251,6 @@ public class I2CDeviceImpl implements I2CDevice {
      */
     @Override
     public int read(final int address, final byte[] data, final int offset, final int size) throws IOException {
-        if((offset + size) > data.length)
-            throw new IndexOutOfBoundsException("buffer overrun");
-
         int ret = getBus().readBytes(this, address, size, offset, data);
         if (ret < 0) {
             throw new I2CIOException("Error reading from " + makeDescription(address) + ". Got '" + ret + "'.", ret);
@@ -284,12 +274,6 @@ public class I2CDeviceImpl implements I2CDevice {
      */
     @Override
     public int read(final byte[] writeData, final int writeOffset, final int writeSize, final byte[] readData, final int readOffset, final int readSize) throws IOException {
-        if((readOffset + readSize) > readData.length)
-            throw new IndexOutOfBoundsException("read buffer overrun");
-
-        if((writeOffset + writeSize) > writeData.length)
-            throw new IndexOutOfBoundsException("write buffer overrun");
-
         int ret = getBus().writeAndReadBytesDirect(this, writeSize, writeOffset, writeData, readSize, readOffset, readData);
         if (ret < 0) {
             throw new I2CIOException("Error reading from " + makeDescription() + ". Got '" + ret + "'.", ret);

--- a/pi4j-core/src/main/java/com/pi4j/io/i2c/impl/I2CProviderImpl.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/i2c/impl/I2CProviderImpl.java
@@ -42,79 +42,12 @@ import com.pi4j.io.i2c.I2CFactory.UnsupportedBusNumberException;
 import com.pi4j.io.i2c.I2CFactoryProvider;
 
 public abstract class I2CProviderImpl implements I2CFactoryProvider {
-
-    /** Singletons */
-    private static final Map<Integer, I2CBus> busSingletons = new HashMap<>();
-
-    /** to lock the creation/destruction of the bus singletons */
-    private static final Lock singletonPerBusLock = new ReentrantLock(true);
-
-    /**
-     * Factory method that returns bus implementation.
-     *
-     * @param newInstanceCandidate if no bus has been created yet, this instance is used
-     * @return appropriate bus implementation
-     * @throws IOException thrown in case there is a problem opening bus file or bus number is not 0 or 1.
-     */
-    protected static I2CBus getBus(int busNumber, Callable<I2CBusImpl> constructor, long lockAquireTimeout, TimeUnit lockAquireTimeoutUnit) throws UnsupportedBusNumberException, IOException {
-        InterruptedException lockException = null;
-        try {
-            if (singletonPerBusLock.tryLock(lockAquireTimeout, lockAquireTimeoutUnit)) {
-                I2CBus bus;
-                try {
-                    bus = busSingletons.get(busNumber);
-
-                    if (bus == null) {
-                        I2CBusImpl newInstanceCandidate = constructor.call();
-                        newInstanceCandidate.open();
-                        bus = newInstanceCandidate;
-                        busSingletons.put(newInstanceCandidate.busNumber, bus);
-                    }
-                } catch (Exception e) {
-                    throw new RuntimeException("Could not instantiate I2CBus", e);
-                } finally {
-                    singletonPerBusLock.unlock();
-                }
-                return bus;
-            }
-        } catch (InterruptedException e) {
-            lockException = e;
-        }
-        throw new RuntimeException("Could not abtain lock to build new bus!", lockException);
-    }
-
-    protected static void closeBus(int busNumber, long lockAquireTimeout, TimeUnit lockAquireTimeoutUnit, Callable<Void> closeAction) {
-        InterruptedException lockException = null;
-        try {
-            if (singletonPerBusLock.tryLock(lockAquireTimeout, lockAquireTimeoutUnit)) {
-                try {
-                    closeAction.call();
-                    return;
-                } catch (Exception e) {
-                    throw new RuntimeException("Cannot close bus", e);
-                } finally {
-                    //  after closing the fd, we must "forget" the singleton bus instance, otherwise further request to this bus will always fail
-                    try {
-                        busSingletons.remove(busNumber);
-                    } finally {
-                        singletonPerBusLock.unlock();
-                    }
-                }
-            }
-        } catch (InterruptedException e) {
-            lockException = e;
-        }
-
-        throw new RuntimeException("Could not abtain lock to close the bus!", lockException);
-    }
-
     public I2CBus getBus(final int busNumber, final long lockAquireTimeout, final TimeUnit lockAquireTimeoutUnit) throws UnsupportedBusNumberException, IOException {
-        return getBus(busNumber, new Callable<I2CBusImpl>() {
-            @Override
-            public I2CBusImpl call() throws UnsupportedBusNumberException {
-                return new I2CBusImpl(busNumber, getFilenameForBusnumber(busNumber), lockAquireTimeout, lockAquireTimeoutUnit);
-            }
-        }, lockAquireTimeout, lockAquireTimeoutUnit);
+        I2CBusImpl result =  new I2CBusImpl(busNumber, getFilenameForBusnumber(busNumber), lockAquireTimeout, lockAquireTimeoutUnit);
+
+        result.open();
+
+        return result;
     }
 
     protected abstract String getFilenameForBusnumber(int busNumber) throws UnsupportedBusNumberException;

--- a/pi4j-core/src/main/java/com/pi4j/jni/I2C.java
+++ b/pi4j-core/src/main/java/com/pi4j/jni/I2C.java
@@ -73,100 +73,101 @@ public class I2C {
     public static native int i2cClose(int fd);
 
     /**
+     * Select the slave device to be target by the bus.
+
+     * @param fd file descriptor
+     * @param deviceAddress device address
+     * @return result of operation. Zero if everything is OK, less than zero if there was an error.
+     */
+    public static native int i2cSlaveSelect(int fd, int deviceAddress);
+
+    /**
      * Writes one byte to i2c. It uses ioctl to define device address and then writes one byte.
      *
      * @param fd            file descriptor of i2c bus
-     * @param deviceAddress device address
      * @param data          byte to be written to the device
      * @return result of operation. Zero if everything is OK, less than zero if there was an error.
      */
-    public static native int i2cWriteByteDirect(int fd, int deviceAddress, byte data);
+    public static native int i2cWriteByteDirect(int fd, byte data);
 
     /**
      * Writes several bytes to i2c. It uses ioctl to define device address and then writes number of bytes defined
      * in size argument.
      *
      * @param fd            file descriptor of i2c bus
-     * @param deviceAddress device address
      * @param size          number of bytes to be written
      * @param offset        offset in buffer to read from
      * @param buffer        data buffer to be written
      * @return result of operation. Zero if everything is OK, less than zero if there was an error.
      */
-    public static native int i2cWriteBytesDirect(int fd, int deviceAddress, int size, int offset, byte[] buffer);
+    public static native int i2cWriteBytesDirect(int fd, int size, int offset, byte[] buffer);
 
     /**
      * Writes one byte to i2c. It uses ioctl to define device address and then writes two bytes: address in
      * the device itself and value.
      *
      * @param fd            file descriptor of i2c bus
-     * @param deviceAddress device address
      * @param localAddress  address in the device
      * @param data          byte to be written to the device
      * @return result of operation. Zero if everything is OK, less than zero if there was an error.
      */
-    public static native int i2cWriteByte(int fd, int deviceAddress, int localAddress, byte data);
+    public static native int i2cWriteByte(int fd, int localAddress, byte data);
 
     /**
      * Writes several bytes to i2c. It uses ioctl to define device address and then writes number of bytes defined
      * in size argument plus one.
      *
      * @param fd            file descriptor of i2c bus
-     * @param deviceAddress device address
      * @param localAddress  address in the device
      * @param size          number of bytes to be written
      * @param offset        offset in buffer to read from
      * @param buffer        data buffer to be written
      * @return result of operation. Zero if everything is OK, less than zero if there was an error.
      */
-    public static native int i2cWriteBytes(int fd, int deviceAddress, int localAddress, int size, int offset, byte[] buffer);
+    public static native int i2cWriteBytes(int fd, int localAddress, int size, int offset, byte[] buffer);
 
     /**
      * Reads one byte from i2c device. It uses ioctl to define device address and then reads one byte.
      *
      * @param fd            file descriptor of i2c bus
-     * @param deviceAddress device address
      * @return positive number (or zero) to 255 if read was successful. Negative number if reading failed.
      */
-    public static native int i2cReadByteDirect(int fd, int deviceAddress);
+    public static native int i2cReadByteDirect(int fd);
 
     /**
      * Reads more bytes from i2c device. It uses ioctl to define device address and then reads
      * size number of bytes.
      *
      * @param fd            file descriptor of i2c bus
-     * @param deviceAddress device address
      * @param size          number of bytes to be read
      * @param offset        offset in buffer to stored read data
      * @param buffer        buffer for data to be written to
      * @return number of bytes read or negative number if reading failed.
      */
-    public static native int i2cReadBytesDirect(int fd, int deviceAddress, int size, int offset, byte[] buffer);
+    public static native int i2cReadBytesDirect(int fd, int size, int offset, byte[] buffer);
 
     /**
      * Reads one byte from i2c device. It uses ioctl to define device address, writes addres in device and then reads
      * one byte.
      *
      * @param fd            file descriptor of i2c bus
-     * @param deviceAddress device address
      * @param localAddress  address in the device
      * @return positive number (or zero) to 255 if read was successful. Negative number if reading failed.
      */
-    public static native int i2cReadByte(int fd, int deviceAddress, int localAddress);
+    public static native int i2cReadByte(int fd, int localAddress);
 
     /**
      * Reads more bytes from i2c device. It uses ioctl to define device address, writes addres in device and then reads
      * size number of bytes.
      *
      * @param fd            file descriptor of i2c bus
-     * @param deviceAddress device address
      * @param localAddress  address in the device
      * @param size          number of bytes to be read
      * @param offset        offset in buffer to stored read data
      * @param buffer        buffer for data to be written to
      * @return number of bytes read or negative number if reading failed.
      */
-    public static native int i2cReadBytes(int fd, int deviceAddress, int localAddress, int size, int offset, byte[] buffer);
+    public static native int i2cReadBytes(int fd, int localAddress, int size, int offset, byte[] buffer);
 
 
     /**
@@ -174,7 +175,6 @@ public class I2C {
      * size number of bytes.
      *
      * @param fd            file descriptor of i2c bus
-     * @param deviceAddress device address
      * @param writeSize     number of bytes to write
      * @param writeOffset   offset in write buffer to start write data
      * @param writeBuffer   buffer for data to be written from
@@ -183,5 +183,5 @@ public class I2C {
      * @param readBuffer    buffer for data read to be stored in
      * @return number of bytes read or negative number if reading failed.
      */
-    public static native int i2cWriteAndReadBytes(int fd, int deviceAddress, int writeSize, int writeOffset, byte[] writeBuffer, int readSize, int readOffset, byte[] readBuffer);
+    public static native int i2cWriteAndReadBytes(int fd, int writeSize, int writeOffset, byte[] writeBuffer, int readSize, int readOffset, byte[] readBuffer);
 }

--- a/pi4j-core/src/test/java/com/pi4j/io/i2c/impl/I2CBusImplTest.java
+++ b/pi4j-core/src/test/java/com/pi4j/io/i2c/impl/I2CBusImplTest.java
@@ -269,42 +269,44 @@ public class I2CBusImplTest {
 //        lock.setAccessible(true);
 //        lock.invoke(bus);
 
+        when(I2C.i2cSlaveSelect(anyInt(), anyInt())).thenReturn(0);
+
         int byteToRead = 123;
-        when(I2C.i2cReadByteDirect(anyInt(), eq(DEVICE_ADDRESS))).thenReturn(byteToRead);
+        when(I2C.i2cReadByteDirect(anyInt())).thenReturn(byteToRead);
         int readByteDirect = bus.readByteDirect(deviceImpl);
         assertEquals("Unexpected result from 'I2CBusImpl.readByteDirect(...)'", byteToRead, readByteDirect);
 
         int localAddress = 815;
-        when(I2C.i2cReadByte(anyInt(), eq(DEVICE_ADDRESS), eq(localAddress))).thenReturn(byteToRead);
+        when(I2C.i2cReadByte(anyInt(), eq(localAddress))).thenReturn(byteToRead);
         int readByte = bus.readByte(deviceImpl, localAddress);
         assertEquals("Unexpected result from 'I2CBusImpl.readByte(...)'", byteToRead, readByte);
 
         byte[] buffer = new byte[2];
-        when(I2C.i2cReadBytes(anyInt(), eq(DEVICE_ADDRESS), eq(localAddress), eq(buffer.length), eq(0), eq(buffer))).thenReturn(buffer.length);
+        when(I2C.i2cReadBytes(anyInt(), eq(localAddress), eq(buffer.length), eq(0), eq(buffer))).thenReturn(buffer.length);
         int readBytes = bus.readBytes(deviceImpl, localAddress, buffer.length, 0, buffer);
         assertEquals("Unexpected result from 'I2CBusImpl.readBytes(...)'", buffer.length, readBytes);
 
         // test write-methods
 
         byte toBeWritten = 13;
-        when(I2C.i2cWriteByteDirect(anyInt(), eq(DEVICE_ADDRESS), eq(toBeWritten))).thenReturn(10);
+        when(I2C.i2cWriteByteDirect(anyInt(), eq(toBeWritten))).thenReturn(10);
         int writeByteDirect = bus.writeByteDirect(deviceImpl, toBeWritten);
         assertEquals("Unexpected result from 'writeByteDirect(...)'", 10, writeByteDirect);
 
-        when(I2C.i2cWriteByte(anyInt(), eq(DEVICE_ADDRESS), eq(localAddress), eq(toBeWritten))).thenReturn(10);
+        when(I2C.i2cWriteByte(anyInt(), eq(localAddress), eq(toBeWritten))).thenReturn(10);
         int writeByte = bus.writeByte(deviceImpl, localAddress, toBeWritten);
         assertEquals("Unexpected result from 'writeByte(...)'", 10, writeByte);
 
         byte[] toBeWrittenBuffer = new byte[] { 47, 11 };
-        when(I2C.i2cWriteBytesDirect(anyInt(), eq(DEVICE_ADDRESS), eq(2), eq(0), any(byte[].class))).thenReturn(10);
+        when(I2C.i2cWriteBytesDirect(anyInt(), eq(2), eq(0), any(byte[].class))).thenReturn(10);
         int writeBytesDirect = bus.writeBytesDirect(deviceImpl, 2, 0, toBeWrittenBuffer);
         assertEquals("Unexpected result from 'writeBytesDirect(...)'", 10, writeBytesDirect);
 
-        when(I2C.i2cWriteBytes(anyInt(), eq(DEVICE_ADDRESS), eq(localAddress), eq(2), eq(0), any(byte[].class))).thenReturn(10);
+        when(I2C.i2cWriteBytes(anyInt(), eq(localAddress), eq(2), eq(0), any(byte[].class))).thenReturn(10);
         int writeBytes = bus.writeBytes(deviceImpl, localAddress, 2, 0, toBeWrittenBuffer);
         assertEquals("Unexpected result from 'writeBytes(...)'", 10, writeBytes);
 
-        when(I2C.i2cWriteAndReadBytes(anyInt(), eq(DEVICE_ADDRESS), eq(2), eq(0), any(byte[].class), eq(2), eq(0), any(byte[].class))).thenReturn(10);
+        when(I2C.i2cWriteAndReadBytes(anyInt(), eq(2), eq(0), any(byte[].class), eq(2), eq(0), any(byte[].class))).thenReturn(10);
         int result = bus.writeAndReadBytesDirect(deviceImpl, 2, 0, toBeWrittenBuffer, 2, 0, buffer);
         assertEquals("Unexpected result from 'writeAndReadBytesDirect(...)'", 10, result);
 

--- a/pi4j-core/src/test/java/com/pi4j/io/i2c/impl/I2CBusImplTest.java
+++ b/pi4j-core/src/test/java/com/pi4j/io/i2c/impl/I2CBusImplTest.java
@@ -112,11 +112,9 @@ public class I2CBusImplTest {
     @Test
     public void testBasics() throws Exception {
 
-        I2CFactory.getInstance(BUSNUMBER);
-
         // test that I2C.i2cOpen was called during setup
 
-        verifyStatic(times(2));
+        verifyStatic(times(1));
         I2C.i2cOpen(eq(FILENAME));
 
         // test for busnumber

--- a/pi4j-core/src/test/java/com/pi4j/io/i2c/impl/I2CDeviceImplTest.java
+++ b/pi4j-core/src/test/java/com/pi4j/io/i2c/impl/I2CDeviceImplTest.java
@@ -81,7 +81,7 @@ public class I2CDeviceImplTest {
                 throw new IOException("Got null-buffer!");
             }
             if (buffer.length < (offset + size)) {
-                throw new IOException("Expected a buffer greater than 'offset + size' (=" + (offset + size) + ") but got '" + buffer.length + "'");
+                throw new IndexOutOfBoundsException("Expected a buffer greater than 'offset + size' (=" + (offset + size) + ") but got '" + buffer.length + "'");
             }
             buffer[offset] = READ_FIRSTBYTE;
             buffer[offset + 1] = READ_SECONDBYTE;
@@ -101,13 +101,13 @@ public class I2CDeviceImplTest {
                 throw new IOException("Expected a writeSize greater than one but got '" + writeSize + "'!");
             }
             if (writeOffset < 0) {
-                throw new IOException("Expected an non-negative writeOffset but got '" + writeOffset + "'!");
+                throw new IllegalArgumentException("Expected an non-negative writeOffset but got '" + writeOffset + "'!");
             }
             if (writeData == null) {
-                throw new IOException("Got null-writeData!");
+                throw new IllegalArgumentException("Got null-writeData!");
             }
             if (writeData.length < (writeOffset + writeSize)) {
-                throw new IOException("Expected a buffer greater than 'offset + size' (=" + (writeOffset + writeSize) + ") but got '" + writeData.length + "'");
+                throw new IndexOutOfBoundsException("Expected a buffer greater than 'offset + size' (=" + (writeOffset + writeSize) + ") but got '" + writeData.length + "'");
             }
             byte firstByte = writeData[writeOffset];
             if (firstByte != WRITE_FIRSTBYTE) {
@@ -122,16 +122,16 @@ public class I2CDeviceImplTest {
             int offset = (Integer) args[args.length - 2];
             byte[] buffer = (byte[]) args[args.length - 1];
             if (size < 2) {
-                throw new IOException("Expected a size greater than one but got '" + size + "'!");
+                throw new IllegalArgumentException("Expected a size greater than one but got '" + size + "'!");
             }
             if (offset < 0) {
-                throw new IOException("Expected an non-negative offset but got '" + offset + "'!");
+                throw new IllegalArgumentException("Expected an non-negative offset but got '" + offset + "'!");
             }
             if (buffer == null) {
-                throw new IOException("Got null-buffer!");
+                throw new IllegalArgumentException("Got null-buffer!");
             }
             if (buffer.length < (offset + size)) {
-                throw new IOException("Expected a buffer greater than 'offset + size' (=" + (offset + size) + ") but got '" + buffer.length + "'");
+                throw new IndexOutOfBoundsException("Expected a buffer greater than 'offset + size' (=" + (offset + size) + ") but got '" + buffer.length + "'");
             }
             buffer[offset] = READ_FIRSTBYTE;
             buffer[offset + 1] = READ_SECONDBYTE;
@@ -151,13 +151,13 @@ public class I2CDeviceImplTest {
                 throw new IOException("Expected a writeSize greater than one but got '" + writeSize + "'!");
             }
             if (writeOffset < 0) {
-                throw new IOException("Expected an non-negative writeOffset but got '" + writeOffset + "'!");
+                throw new IllegalArgumentException("Expected an non-negative writeOffset but got '" + writeOffset + "'!");
             }
             if (writeData == null) {
-                throw new IOException("Got null-writeData!");
+                throw new IllegalArgumentException("Got null-writeData!");
             }
             if (writeData.length < (writeOffset + writeSize)) {
-                throw new IOException("Expected a buffer greater than 'offset + size' (=" + (writeOffset + writeSize) + ") but got '" + writeData.length + "'");
+                throw new IndexOutOfBoundsException("Expected a buffer greater than 'offset + size' (=" + (writeOffset + writeSize) + ") but got '" + writeData.length + "'");
             }
 
             return null; // void
@@ -260,7 +260,7 @@ public class I2CDeviceImplTest {
         try {
             device.read(new byte[2], 1, 2);
             fail("Expected 'read(...)' to throw an exception but got none!");
-        } catch (IOException e) {
+        } catch (IndexOutOfBoundsException e) {
             // expected
         }
 
@@ -298,7 +298,7 @@ public class I2CDeviceImplTest {
         try {
             device.read(LOCALADDRESS, new byte[2], 1, 2);
             fail("Expected 'read(...)' to throw an exception but got none!");
-        } catch (IOException e) {
+        } catch (IndexOutOfBoundsException e) {
             // expected
         }
 
@@ -390,7 +390,7 @@ public class I2CDeviceImplTest {
         try {
             device.write(new byte[2], 1, 2);
             fail("Expected 'write(...)' to throw an exception but got none!");
-        } catch (IOException e) {
+        } catch (IndexOutOfBoundsException e) {
             // expected
         }
 
@@ -417,7 +417,7 @@ public class I2CDeviceImplTest {
         try {
             device.write(LOCALADDRESS, new byte[2], 1, 2);
             fail("Expected 'write(...)' to throw an exception but got none!");
-        } catch (IOException e) {
+        } catch (IndexOutOfBoundsException e) {
             // expected
         }
 

--- a/pi4j-core/src/test/java/com/pi4j/io/i2c/impl/I2CDeviceImplTest.java
+++ b/pi4j-core/src/test/java/com/pi4j/io/i2c/impl/I2CDeviceImplTest.java
@@ -176,7 +176,7 @@ public class I2CDeviceImplTest {
 
         // simple run runnable and return result. the original method
         // adds locking but we want to test I2CDeviceImpl not I2CBusImpl!
-        when(bus.runActionOnExclusivLockedBus(any(Callable.class))).thenAnswer(new Answer<Object>() {
+        when(bus.runBusLockedDeviceAction(any(), any(Callable.class))).thenAnswer(new Answer<Object>() {
             @Override
             public Object answer(InvocationOnMock invocation) throws Throwable {
                 Callable<Object> action = (Callable<Object>) invocation.getArguments()[0];

--- a/pi4j-native/src/main/native/com_pi4j_jni_I2C.c
+++ b/pi4j-native/src/main/native/com_pi4j_jni_I2C.c
@@ -36,12 +36,28 @@
 #include <sys/stat.h>
 #include <unistd.h>
 #include <jni.h>
+#include <errno.h>
 
 #include "com_pi4j_jni_I2C.h"
 
 /* Source for com_pi4j_jni_I2C */
 
-unsigned char buf[257];	
+/*
+ * Class:     com_pi4j_jni_I2C
+ * Method:    i2cSlaveSelect
+ * Signature: (II)I
+ */
+JNIEXPORT jint JNICALL Java_com_pi4j_jni_I2C_i2cSlaveSelect
+ (JNIEnv *env, jclass obj, jint fd, jint deviceAddress)
+{
+   int response = ioctl(fd, I2C_SLAVE, deviceAddress);
+
+   if (response < 0) {
+       return -errno - 10000;
+   }
+
+   return response;
+}
 
 /*
  * Class:     com_pi4j_jni_I2C
@@ -51,11 +67,11 @@ unsigned char buf[257];
 JNIEXPORT jint JNICALL Java_com_pi4j_jni_I2C_i2cOpen
   (JNIEnv *env, jclass obj, jstring device)
 {
-	char fileName[256];
-	int len = (*env)->GetStringLength(env, device);
-	(*env)->GetStringUTFRegion(env, device, 0, len, fileName);
+    char fileName[256];
+    int len = (*env)->GetStringLength(env, device);
+    (*env)->GetStringUTFRegion(env, device, 0, len, fileName);
 
-	return open(fileName, O_RDWR);
+    return open(fileName, O_RDWR);
 }
 
 /*
@@ -66,59 +82,47 @@ JNIEXPORT jint JNICALL Java_com_pi4j_jni_I2C_i2cOpen
 JNIEXPORT jint JNICALL Java_com_pi4j_jni_I2C_i2cClose
   (JNIEnv *env, jclass obj, jint fd)
 {
-	return close(fd);
+    return close(fd);
 }
 
 /*
  * Class:     com_pi4j_jni_I2C
  * Method:    i2cWriteByteDirect
- * Signature: (IIB)I
+ * Signature: (IB)I
  */
 JNIEXPORT jint JNICALL Java_com_pi4j_jni_I2C_i2cWriteByteDirect
-  (JNIEnv *env, jclass obj, jint fd, jint deviceAddress, jbyte b)
+  (JNIEnv *env, jclass obj, jint fd, jbyte b)
 {
-    int response = ioctl(fd, I2C_SLAVE, deviceAddress);
-
-    if (response < 0) {
-        return response - 10000;
-	}
-
-	buf[0] = b;
+    int response;
     
-    response = write(fd, buf, 1);
-	if (response != 1) {
-	    return response - 20000;
-	}
-	
+    response = write(fd, &b, 1);
+    if(response != 1) {
+        return -errno - 20000;
+    }
+    
     return 0;
 }
 
 /*
  * Class:     com_pi4j_jni_I2C
  * Method:    i2cWriteBytesDirect
- * Signature: (IIII[B)I
+ * Signature: (III[B)I
  */
 JNIEXPORT jint JNICALL Java_com_pi4j_jni_I2C_i2cWriteBytesDirect
-  (JNIEnv *env, jclass obj, jint fd, jint deviceAddress, jint size, jint offset, jbyteArray bytes)
+  (JNIEnv *env, jclass obj, jint fd, jint size, jint offset, jbyteArray bytes)
 {
-    int i;
-
-    int response = ioctl(fd, I2C_SLAVE, deviceAddress);
-    if (response < 0) {
-        return response - 10000;
-	}
+    int response;
 
     jbyte *body = (*env)->GetByteArrayElements(env, bytes, 0);
-    for (i = 0; i < size; i++) {
-      buf[i] = body[i + offset];
-    }
+
+    response = write(fd, body + offset, size);
+
     (*env)->ReleaseByteArrayElements(env, bytes, body, 0);
+
+    if (response != size) {
+        return -errno - 20000;
+    }
     
-    response = write(fd, buf, size);
-	if (response != size) {
-	    return response - 20000;
-	}
-	
     return 0;
 }
 
@@ -126,46 +130,44 @@ JNIEXPORT jint JNICALL Java_com_pi4j_jni_I2C_i2cWriteBytesDirect
 /*
  * Class:     com_pi4j_wiringpi_I2C
  * Method:    i2cWriteByte
- * Signature: (IIIB)I
+ * Signature: (IIB)I
  */
 JNIEXPORT jint JNICALL Java_com_pi4j_jni_I2C_i2cWriteByte
-  (JNIEnv *env, jclass obj, jint fd, jint deviceAddress, jint localAddress, jbyte b)
+  (JNIEnv *env, jclass obj, jint fd, jint localAddress, jbyte b)
   
 {
-    int response = ioctl(fd, I2C_SLAVE, deviceAddress);
+    int response;
+    unsigned char buf[2];
 
-    if (response < 0) {
-        return response - 10000;
-	}
-
-	buf[0] = localAddress;
-	buf[1] = b;
+    buf[0] = localAddress;
+    buf[1] = b;
     
     response = write(fd, buf, 2);
-	if (response != 2) {
-	    return response - 20000;
-	}
-	
+    if (response != 2) {
+        return -errno - 20000;
+    }
+    
     return 0;
 }
 
 /*
  * Class:     com_pi4j_jni_I2C
  * Method:    i2cWriteBytes
- * Signature: (IIIII[B)I
+ * Signature: (IIII[B)I
  */
 JNIEXPORT jint JNICALL Java_com_pi4j_jni_I2C_i2cWriteBytes
-  (JNIEnv *env, jclass obj, jint fd, jint deviceAddress, jint localAddress, jint size, jint offset, jbyteArray bytes)
+  (JNIEnv *env, jclass obj, jint fd, jint localAddress, jint size, jint offset, jbyteArray bytes)
   
 {
     int i;
+    unsigned char buf[257];
+    int response;
 
-    int response = ioctl(fd, I2C_SLAVE, deviceAddress);
-    if (response < 0) {
-        return response - 10000;
-	}
+    if(size > 256) {
+      return -E2BIG;
+    }
 
-	buf[0] = localAddress;
+    buf[0] = localAddress;
     
     jbyte *body = (*env)->GetByteArrayElements(env, bytes, 0);
     for (i = 0; i < size; i++) {
@@ -174,10 +176,10 @@ JNIEXPORT jint JNICALL Java_com_pi4j_jni_I2C_i2cWriteBytes
     (*env)->ReleaseByteArrayElements(env, bytes, body, 0);
     
     response = write(fd, buf, size + 1);
-	if (response != size + 1) {
-	    return response - 20000;
-	}
-	
+    if (response != size + 1) {
+        return -errno - 20000;
+    }
+    
     return 0;
 }
 
@@ -185,49 +187,40 @@ JNIEXPORT jint JNICALL Java_com_pi4j_jni_I2C_i2cWriteBytes
 /*
  * Class:     com_pi4j_jni_I2C
  * Method:    i2cReadByteDirect
- * Signature: (II)I
+ * Signature: (I)I
  */
 JNIEXPORT jint JNICALL Java_com_pi4j_jni_I2C_i2cReadByteDirect
-  (JNIEnv *env, jclass obj, jint fd, jint deviceAddress)
+  (JNIEnv *env, jclass obj, jint fd)
 {
-    int response = ioctl(fd, I2C_SLAVE, deviceAddress);
-    if (response < 0) {
-        return response - 10000;
-	}
+    unsigned char data;
+    int response;
 
-    response = read(fd, buf, 1);
+    response = read(fd, &data, 1);
     if (response != 1) {
-	    return response - 30000;
-	}
+        return -errno - 30000;
+    }
 
-    response = (int)buf[0];
-
-    return response;
+    return data;
 }
 
 /*
  * Class:     com_pi4j_jni_I2C
  * Method:    i2cReadBytesDirect
- * Signature: (IIII[B)I
+ * Signature: (III[B)I
  */
 JNIEXPORT jint JNICALL Java_com_pi4j_jni_I2C_i2cReadBytesDirect
-  (JNIEnv *env, jclass obj, jint fd, jint deviceAddress, jint size, jint offset, jbyteArray bytes)
+  (JNIEnv *env, jclass obj, jint fd, jint size, jint offset, jbyteArray bytes)
 {
-    int i;
-    
-    int response = ioctl(fd, I2C_SLAVE, deviceAddress);
+    int response;
+
+    jbyte *body = (*env)->GetByteArrayElements(env, bytes, 0);
+
+    response = read(fd, body + offset, size);
+
+    (*env)->ReleaseByteArrayElements(env, bytes, body, 0);
+
     if (response < 0) {
-        return response - 10000;
-    }
-
-    response = read(fd, buf, size);
-    if (response > 0) {
-
-        jbyte *body = (*env)->GetByteArrayElements(env, bytes, 0);
-        for (i = 0; i < size; i++) {
-            body[i + offset] = buf[i];
-        }
-        (*env)->ReleaseByteArrayElements(env, bytes, body, 0);
+        return -errno - 30000;
     }
 
     return response;
@@ -237,120 +230,88 @@ JNIEXPORT jint JNICALL Java_com_pi4j_jni_I2C_i2cReadBytesDirect
 /*
  * Class:     com_pi4j_jni_I2C
  * Method:    i2cReadByte
- * Signature: (III)I
+ * Signature: (II)I
  */
 JNIEXPORT jint JNICALL Java_com_pi4j_jni_I2C_i2cReadByte
-  (JNIEnv *env, jclass obj, jint fd, jint deviceAddress, jint localAddress)
+  (JNIEnv *env, jclass obj, jint fd, jint localAddress)
 {
-    int response = ioctl(fd, I2C_SLAVE, deviceAddress);
-    if (response < 0) {
-        return response - 10000;
-    }
+    unsigned char data;
+    int response;
 
-    buf[0] = localAddress;												
-	
-    response = write(fd, buf, 1);
+    response = write(fd, &localAddress, 1);
     if (response != 1) {
-        return response - 20000;
-    }
-	
-    response = ioctl(fd, I2C_SLAVE, deviceAddress);
-    if (response < 0) {
-        return response - 10000;
+        return -errno - 20000;
     }
 
-    response = read(fd, buf, 1);
+    response = read(fd, &data, 1);
     if (response != 1) {
-	    return response - 30000;
+        return -errno - 30000;
     }
 
-    response = (int)buf[0];
-
-    return response;
+    return data;
 }
 
 /*
  * Class:     com_pi4j_jni_I2C
  * Method:    i2cReadBytes
- * Signature: (IIIII[B)I
+ * Signature: (IIII[B)I
  */
 JNIEXPORT jint JNICALL Java_com_pi4j_jni_I2C_i2cReadBytes
-  (JNIEnv *env, jclass obj, jint fd, jint deviceAddress, jint localAddress, jint size, jint offset, jbyteArray bytes)
+  (JNIEnv *env, jclass obj, jint fd, jint localAddress, jint size, jint offset, jbyteArray bytes)
 {
-    int i;
-    
-    int response = ioctl(fd, I2C_SLAVE, deviceAddress);
-    if (response < 0) {
-        return response - 10000;
-    }
+    int response;
 
-    buf[0] = localAddress;
-	
-    response = write(fd, buf, 1);
+    response = write(fd, &localAddress, 1);
     if (response != 1) {
-        return response - 20000;
+        return -errno - 20000;
     }
-	
-    response = ioctl(fd, I2C_SLAVE, deviceAddress);
+
+    jbyte *body = (*env)->GetByteArrayElements(env, bytes, 0);
+
+    response = read(fd, body + offset, size);
+
+    (*env)->ReleaseByteArrayElements(env, bytes, body, 0);
+
     if (response < 0) {
-        return response - 10000;
-    }
-
-    response = read(fd, buf, size);
-    if (response > 0) {
-
-        jbyte *body = (*env)->GetByteArrayElements(env, bytes, 0);
-        for (i = 0; i < size; i++) {
-            body[i + offset] = buf[i];
-        }
-        (*env)->ReleaseByteArrayElements(env, bytes, body, 0);
+        return -errno - 30000;
     }
 
     return response;
 }
-
 
 /*
 Class:     com_pi4j_jni_I2C
 Method:    i2cWriteAndReadBytes
-Signature: (IIII[BII[B)I
+Signature: (III[BII[B)I
 */
 JNIEXPORT jint JNICALL Java_com_pi4j_jni_I2C_i2cWriteAndReadBytes
-(JNIEnv *env, jclass obj, jint fd, jint deviceAddress, jint writeSize, jint writeOffset, jbyteArray writeBytes, jint readSize, jint readOffset, jbyteArray readBytes)
+  (JNIEnv *env, jclass obj, jint fd, jint writeSize, jint writeOffset, jbyteArray writeBytes, jint readSize, jint readOffset, jbyteArray readBytes)
 {
-    int i;
-
-    int response = ioctl(fd, I2C_SLAVE, deviceAddress);
-    if (response < 0) {
-        return response - 10000;
-    }
+    jbyte *body;
+    int response;
 
     // writing writeSize bytes
-    jbyte *body = (*env)->GetByteArrayElements(env, writeBytes, 0);
-    for (i = 0; i < writeSize; i++) {
-        buf[i] = body[i + writeOffset];
-    }
+    body = (*env)->GetByteArrayElements(env, writeBytes, 0);
+
+    response = write(fd, body + writeOffset, writeSize);
+
     (*env)->ReleaseByteArrayElements(env, writeBytes, body, 0);
 
-    response = write(fd, buf, writeSize);
     if (response != writeSize) {
-        return response - 20000;
+        return -errno - 20000;
     }
 
     // reading bytes
-    response = ioctl(fd, I2C_SLAVE, deviceAddress);
-    if (response < 0) {
-        return response - 10000;
-    }
+    body = (*env)->GetByteArrayElements(env, readBytes, 0);
 
-    response = read(fd, buf, readSize);
-    if (response > 0) {
-        body = (*env)->GetByteArrayElements(env, readBytes, 0);
-        for (i = 0; i < readSize; i++) {
-            body[i + readOffset] = buf[i];
-        }
-        (*env)->ReleaseByteArrayElements(env, readBytes, body, 0);
+    response = read(fd, body + readOffset, readSize);
+
+    (*env)->ReleaseByteArrayElements(env, readBytes, body, 0);
+
+    if (response < 0) {
+        return -errno - 30000;
     }
 
     return response;
 }
+

--- a/pi4j-native/src/main/native/com_pi4j_jni_I2C.h
+++ b/pi4j-native/src/main/native/com_pi4j_jni_I2C.h
@@ -35,6 +35,15 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
+
+/*
+ * Class:     com_pi4j_jni_I2C
+ * Method:    i2cSlaveSelect
+ * Signature: (II)I
+ */
+JNIEXPORT jint JNICALL Java_com_pi4j_jni_I2C_i2cSlaveSelect
+   (JNIEnv *env, jclass obj, jint fd, jint deviceAddress);
+
 /*
  * Class:     com_pi4j_jni_I2C
  * Method:    i2cOpen
@@ -54,74 +63,74 @@ JNIEXPORT jint JNICALL Java_com_pi4j_jni_I2C_i2cClose
 /*
  * Class:     com_pi4j_jni_I2C
  * Method:    i2cWriteByteDirect
- * Signature: (IIB)I
+ * Signature: (IB)I
  */
 JNIEXPORT jint JNICALL Java_com_pi4j_jni_I2C_i2cWriteByteDirect
-  (JNIEnv *, jclass, jint, jint, jbyte);
+  (JNIEnv *, jclass, jint, jbyte);
 
 /*
  * Class:     com_pi4j_jni_I2C
  * Method:    i2cWriteBytesDirect
- * Signature: (IIII[B)I
+ * Signature: (III[B)I
  */
 JNIEXPORT jint JNICALL Java_com_pi4j_jni_I2C_i2cWriteBytesDirect
-  (JNIEnv *, jclass, jint, jint, jint, jint, jbyteArray);
+  (JNIEnv *, jclass, jint, jint, jint, jbyteArray);
 
 /*
  * Class:     com_pi4j_jni_I2C
  * Method:    i2cWriteByte
- * Signature: (IIIB)I
+ * Signature: (IIB)I
  */
 JNIEXPORT jint JNICALL Java_com_pi4j_jni_I2C_i2cWriteByte
-  (JNIEnv *, jclass, jint, jint, jint, jbyte);
+  (JNIEnv *, jclass, jint, jint, jbyte);
 
 /*
  * Class:     com_pi4j_jni_I2C
  * Method:    i2cWriteBytes
- * Signature: (IIIII[B)I
- */
-JNIEXPORT jint JNICALL Java_com_pi4j_jni_I2C_i2cWriteBytes
-  (JNIEnv *, jclass, jint, jint, jint, jint, jint, jbyteArray);
-
-/*
- * Class:     com_pi4j_jni_I2C
- * Method:    i2cReadByteDirect
- * Signature: (II)I
- */
-JNIEXPORT jint JNICALL Java_com_pi4j_jni_I2C_i2cReadByteDirect
-  (JNIEnv *, jclass, jint, jint);
-
-/*
- * Class:     com_pi4j_jni_I2C
- * Method:    i2cReadBytesDirect
  * Signature: (IIII[B)I
  */
-JNIEXPORT jint JNICALL Java_com_pi4j_jni_I2C_i2cReadBytesDirect
+JNIEXPORT jint JNICALL Java_com_pi4j_jni_I2C_i2cWriteBytes
   (JNIEnv *, jclass, jint, jint, jint, jint, jbyteArray);
 
 /*
  * Class:     com_pi4j_jni_I2C
+ * Method:    i2cReadByteDirect
+ * Signature: (I)I
+ */
+JNIEXPORT jint JNICALL Java_com_pi4j_jni_I2C_i2cReadByteDirect
+  (JNIEnv *, jclass, jint);
+
+/*
+ * Class:     com_pi4j_jni_I2C
+ * Method:    i2cReadBytesDirect
+ * Signature: (III[B)I
+ */
+JNIEXPORT jint JNICALL Java_com_pi4j_jni_I2C_i2cReadBytesDirect
+  (JNIEnv *, jclass, jint, jint, jint, jbyteArray);
+
+/*
+ * Class:     com_pi4j_jni_I2C
  * Method:    i2cReadByte
- * Signature: (III)I
+ * Signature: (II)I
  */
 JNIEXPORT jint JNICALL Java_com_pi4j_jni_I2C_i2cReadByte
-  (JNIEnv *, jclass, jint, jint, jint);
+  (JNIEnv *, jclass, jint, jint);
 
 /*
  * Class:     com_pi4j_jni_I2C
  * Method:    i2cReadBytes
- * Signature: (IIIII[B)I
+ * Signature: (IIII[B)I
  */
 JNIEXPORT jint JNICALL Java_com_pi4j_jni_I2C_i2cReadBytes
-  (JNIEnv *, jclass, jint, jint, jint, jint, jint, jbyteArray);
+  (JNIEnv *, jclass, jint, jint, jint, jint, jbyteArray);
 
 /*
  * Class:     com_pi4j_jni_I2C
  * Method:    i2cWriteAndReadBytes
- * Signature: (IIII[BII[B)I
+ * Signature: (III[BII[B)I
  */
 JNIEXPORT jint JNICALL Java_com_pi4j_jni_I2C_i2cWriteAndReadBytes
-  (JNIEnv *, jclass, jint, jint, jint, jint, jbyteArray, jint, jint, jbyteArray);
+  (JNIEnv *, jclass, jint, jint, jint, jbyteArray, jint, jint, jbyteArray);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
addresses #260 #259 #262

replaces PR #261
- reduced ioctl calls
- removed shared static buffer in native impl
- removed locks around I2C bus provider- can return multiple bus instances now
- cleaned up bus impl with Java 8 lambdas
- direct referencing of stack-allocated data and java byte array contents
- native calls now return errno
- i2c impl throws an IOException subclass with error code
- bounds checks for buffers that throw IllegalArgumentException and InvalidArgumentException
