### PR TITLE
Allow I2CLcdDisplay to turn on / off backlight without waiting for next write

### DIFF
--- a/pi4j-device/src/main/java/com/pi4j/component/lcd/impl/I2CLcdDisplay.java
+++ b/pi4j-device/src/main/java/com/pi4j/component/lcd/impl/I2CLcdDisplay.java
@@ -333,6 +333,10 @@ public class I2CLcdDisplay extends LCDBase implements LCD {
      */
     public void setBacklight(boolean backlight) {
         this.backlight = backlight;
+
+        dev.write((byte)(backlight
+                ? 1 << (byte)backlightBit
+                : 0 << (byte)backlightBit));
     }
 
     private void setRS(boolean val) {


### PR DESCRIPTION
Currently, If you try to turn on/off the backlight you have to wait till the next write to the device. This fix will instantly turn the backlight on or off.