### PR TITLE
Fix build project on macOS

### DIFF
--- a/pi4j-distribution/pom.xml
+++ b/pi4j-distribution/pom.xml
@@ -488,6 +488,7 @@
 				<artifactId>maven-assembly-plugin</artifactId>
 				<configuration>
 					<appendAssemblyId>false</appendAssemblyId>
+					<tarLongFileMode>posix</tarLongFileMode>
 					<finalName>pi4j-${project.version}</finalName>
 					<descriptors>
 				    	<descriptor>src/assembly/distribution.xml</descriptor>

--- a/pi4j-distribution/src/assembly/distribution.xml
+++ b/pi4j-distribution/src/assembly/distribution.xml
@@ -8,7 +8,7 @@
   <fileSets>
     <fileSet>
       <directory>target/distro-contents</directory>
-      <outputDirectory>/</outputDirectory>
+      <outputDirectory/>
     </fileSet>
   </fileSets>
 </assembly>

--- a/pom.xml
+++ b/pom.xml
@@ -194,7 +194,7 @@
         <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
         <maven-javadoc-plugin.version>2.10.4</maven-javadoc-plugin.version>
         <maven-site-plugin.version>3.4</maven-site-plugin.version>
-        <maven-assembly-plugin.version>2.6</maven-assembly-plugin.version>
+        <maven-assembly-plugin.version>3.0.0</maven-assembly-plugin.version>
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
         <maven-scm-plugin.version>1.9.5</maven-scm-plugin.version>
         <maven-bundle-plugin.version>3.2.0</maven-bundle-plugin.version>


### PR DESCRIPTION
I've got the following error during building project on macOS:
```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 41.496 s
[INFO] Finished at: 2017-02-10T03:22:08+06:00
[INFO] Final Memory: 63M/621M
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-assembly-plugin:3.0.0:single (make-distribution-assembly) on project pi4j-distribution: Execution make-distribution-assembly of goal org.apache.maven.plugins:maven-assembly-plugin:3.0.0:single failed: group id '593637566' is too big ( > 2097151 ). Use STAR or POSIX extensions to overcome this limit -> [Help 1]
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/PluginExecutionException
[ERROR]
[ERROR] After correcting the problems, you can resume the build with the command
[ERROR]   mvn <goals> -rf :pi4j-distribution
```

This PR allows to build Pi4J on OSX

[FYI] My environment:
![image](https://cloud.githubusercontent.com/assets/578021/22803964/9e6d35fc-ef49-11e6-95b3-7f131b04c736.png)
