### PR TITLE
Prevent usage of the old JUnit version (4.11)

### DIFF
--- a/pi4j-core/pom.xml
+++ b/pi4j-core/pom.xml
@@ -28,10 +28,6 @@
 			<scope>provided</scope>
 		</dependency>
 
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-        </dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>
 			<artifactId>mockito-all</artifactId>

--- a/pi4j-gpio-extension/pom.xml
+++ b/pi4j-gpio-extension/pom.xml
@@ -24,12 +24,6 @@
 			<version>1.9</version>
 			<scope>test</scope>
 		</dependency>
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.11</version>
-			<scope>test</scope>
-		</dependency>
 	</dependencies>
 
 	<!-- BUILD INSTRUCTIONS -->

--- a/pom.xml
+++ b/pom.xml
@@ -277,7 +277,6 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <scope>test</scope>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Duplicated declarations of JUnit library were also removed
It is declared in the root pom.xml