### PR TITLE
Update Maven plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,6 +99,11 @@
 		<module>pi4j-distribution</module>
 	</modules>
 
+    <!-- PROJECT PREREQUISITES -->
+	<prerequisites>
+		<maven>3.0.5</maven>
+	</prerequisites>
+
 	<!-- BUILD PROPERTIES -->
 	<properties>
 
@@ -189,19 +194,19 @@
 
         <!-- PLUGIN VERSIONS -->
         <maven-jar-plugin.version>3.0.2</maven-jar-plugin.version>
-        <maven-dependency-plugin.version>2.10</maven-dependency-plugin.version>
-        <maven-compiler-plugin.version>3.5.1</maven-compiler-plugin.version>
+        <maven-dependency-plugin.version>3.0.0</maven-dependency-plugin.version>
+        <maven-compiler-plugin.version>3.6.1</maven-compiler-plugin.version>
         <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
         <maven-javadoc-plugin.version>2.10.4</maven-javadoc-plugin.version>
-        <maven-site-plugin.version>3.4</maven-site-plugin.version>
+        <maven-site-plugin.version>3.6</maven-site-plugin.version>
         <maven-assembly-plugin.version>3.0.0</maven-assembly-plugin.version>
         <maven-gpg-plugin.version>1.6</maven-gpg-plugin.version>
         <maven-scm-plugin.version>1.9.5</maven-scm-plugin.version>
         <maven-bundle-plugin.version>3.2.0</maven-bundle-plugin.version>
         <maven-antrun-plugin.version>1.8</maven-antrun-plugin.version>
         <native-maven-plugin.version>1.0-alpha-8</native-maven-plugin.version>
-        <license-maven-plugin.version>1.9</license-maven-plugin.version>
-        <build-helper-maven-plugin.version>1.9</build-helper-maven-plugin.version>
+        <license-maven-plugin.version>1.12</license-maven-plugin.version>
+        <build-helper-maven-plugin.version>3.0.0</build-helper-maven-plugin.version>
         <site-maven-plugin.version>0.12</site-maven-plugin.version>
         <jdeb.version>1.5</jdeb.version>
         <exec-maven-plugin.version>1.5.0</exec-maven-plugin.version>


### PR DESCRIPTION
Minimum version of Maven was also configured in the "prerequisites" section
It it the minimal version which is required by all plugins

```
[INFO]
[INFO] Require Maven 3.0.5 to use the following plugin updates:
[INFO]   org.apache.felix:maven-bundle-plugin .......................... 3.2.0
[INFO]
[INFO]
```