### PR TITLE
Fix LinuxFile reflection init (#310)

### DIFF
--- a/pi4j-core/src/main/java/com/pi4j/io/file/LinuxFile.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/file/LinuxFile.java
@@ -75,7 +75,7 @@ public class LinuxFile extends RandomAccessFile {
 
             addressField = Buffer.class.getDeclaredField("address");
             capacityField = Buffer.class.getDeclaredField("capacity");
-            cleanerField = Buffer.class.getDeclaredField("cleaner");
+            cleanerField = dbb.getDeclaredField("cleaner");
             directByteBufferConstructor = dbb.getDeclaredConstructor(
                     new Class[] { int.class, long.class, FileDescriptor.class, Runnable.class });
 
@@ -84,11 +84,11 @@ public class LinuxFile extends RandomAccessFile {
             cleanerField.setAccessible(true);
             directByteBufferConstructor.setAccessible(true);
         } catch (NoSuchFieldException e) {
-            throw new InternalError();
+            throw new InternalError(e.getMessage());
         } catch (ClassNotFoundException e) {
-            throw new InternalError();
+            throw new InternalError(e.getMessage());
         } catch (NoSuchMethodException e) {
-            throw new InternalError();
+            throw new InternalError(e.getMessage());
         }
     }
 
@@ -313,7 +313,7 @@ public class LinuxFile extends RandomAccessFile {
             ((Cleaner)cleanerField.get(mappedBuffer)).clean();
         } catch (IllegalAccessException e) {
             e.printStackTrace();
-            throw new InternalError();
+            throw new InternalError(e.getMessage());
         }
     }
 
@@ -324,11 +324,11 @@ public class LinuxFile extends RandomAccessFile {
             dbb = (MappedByteBuffer)directByteBufferConstructor.newInstance(
                     new Object[] { new Integer(size), new Long(addr), this.getFD(), unmapper });
         } catch (InstantiationException e) {
-            throw new InternalError();
+            throw new InternalError(e.getMessage());
         } catch (IllegalAccessException e) {
-            throw new InternalError();
+            throw new InternalError(e.getMessage());
         } catch (InvocationTargetException e) {
-            throw new InternalError();
+            throw new InternalError(e.getMessage());
         }
         return dbb;
     }


### PR DESCRIPTION
**Addresses #310, related to new LinuxFile implementation merged in with #289**

Fixes incorrect java reflection field lookup in the LinuxFile static initialization. 

Not sure how this snuck past testing, but I was sure to test the fail case this time, along with the fix. 