### PR TITLE
Raspberry supports only 2 i2c busses

### DIFF
--- a/pi4j-core/src/main/java/com/pi4j/io/i2c/impl/I2CFactoryProviderRaspberryPi.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/i2c/impl/I2CFactoryProviderRaspberryPi.java
@@ -35,7 +35,7 @@ public class I2CFactoryProviderRaspberryPi extends I2CProviderImpl {
 
     @Override
     protected String getFilenameForBusnumber(int busNumber) throws UnsupportedBusNumberException {
-        if (busNumber < 0) {
+        if ((busNumber < 0) || (busNumber > 1) {
             throw new UnsupportedBusNumberException();
         }
 

--- a/pi4j-core/src/main/java/com/pi4j/io/i2c/impl/I2CFactoryProviderRaspberryPi.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/i2c/impl/I2CFactoryProviderRaspberryPi.java
@@ -35,7 +35,7 @@ public class I2CFactoryProviderRaspberryPi extends I2CProviderImpl {
 
     @Override
     protected String getFilenameForBusnumber(int busNumber) throws UnsupportedBusNumberException {
-        if (busNumber < 0) {
+        if ((busNumber < 0) || (busNumber > 1)) {
             throw new UnsupportedBusNumberException();
         }
 

--- a/pi4j-core/src/main/java/com/pi4j/io/i2c/impl/I2CFactoryProviderRaspberryPi.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/i2c/impl/I2CFactoryProviderRaspberryPi.java
@@ -35,7 +35,7 @@ public class I2CFactoryProviderRaspberryPi extends I2CProviderImpl {
 
     @Override
     protected String getFilenameForBusnumber(int busNumber) throws UnsupportedBusNumberException {
-        if ((busNumber < 0) || (busNumber > 1) {
+        if ((busNumber < 0) || (busNumber > 1)) {
             throw new UnsupportedBusNumberException();
         }
 


### PR DESCRIPTION
Hi,

quick&dirty fix for number of available busses on RaspberryPi.

Better solution should be try to open an device on bus.
And if open failes throw an UnsupportedBusNumberException exception.