### PR TITLE
IRQ Monitoring for PCF8574

### DIFF
--- a/pi4j-core/pom.xml
+++ b/pi4j-core/pom.xml
@@ -15,6 +15,11 @@
 
 	<!-- PROJECT DEPENDENCIES -->
 	<dependencies>
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<scope>provided</scope>
+		</dependency>
 
         <!-- while the pi4j-native dependency is not needed for compiling this
              project, including it here ensures that it gets compiled in the maven

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/event/GpioPinListenerDigital.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/event/GpioPinListenerDigital.java
@@ -30,7 +30,6 @@ package com.pi4j.io.gpio.event;
  */
 
 
-
 /**
  * <p> This interface implements the callback event handler for GPIO pin state changes.</p>
  *
@@ -50,6 +49,7 @@ package com.pi4j.io.gpio.event;
  * @author Robert Savage (<a
  *         href="http://www.savagehomeautomation.com">http://www.savagehomeautomation.com</a>)
  */
+@FunctionalInterface
 public interface GpioPinListenerDigital extends GpioPinListener {
 
     void handleGpioPinDigitalStateChangeEvent(GpioPinDigitalStateChangeEvent event);

--- a/pi4j-device/pom.xml
+++ b/pi4j-device/pom.xml
@@ -14,6 +14,12 @@
 	<!-- PROJECT DEPENDENCIES -->
 	<dependencies>
 		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
 			<groupId>com.pi4j</groupId>
 			<artifactId>pi4j-core</artifactId>
 			<version>${project.version}</version>

--- a/pi4j-example/pom.xml
+++ b/pi4j-example/pom.xml
@@ -15,6 +15,12 @@
 
 	<!-- DEPENDENCIES -->
 	<dependencies>
+		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<scope>provided</scope>
+		</dependency>
+
 <!-- START SNIPPET: maven-dependency-snippet -->
 <dependency>
 	<groupId>com.pi4j</groupId>

--- a/pi4j-example/src/main/java/PCF8574GpioExample.java
+++ b/pi4j-example/src/main/java/PCF8574GpioExample.java
@@ -54,7 +54,7 @@ import com.pi4j.io.i2c.I2CFactory.UnsupportedBusNumberException;
  *
  * <p>
  * The PCF8574 is connected via I2C connection to the Raspberry Pi and provides
- * 16 GPIO pins that can be used for either digital input or digital output pins.
+ * 8 GPIO pins that can be used for either digital input or digital output pins.
  * </p>
  *
  * @author Robert Savage
@@ -68,7 +68,7 @@ public class PCF8574GpioExample {
         // create gpio controller
         final GpioController gpio = GpioFactory.getInstance();
 
-        // create custom MCP23017 GPIO provider
+        // create custom PCF8574 GPIO provider
         final PCF8574GpioProvider provider = new PCF8574GpioProvider(I2CBus.BUS_1, PCF8574GpioProvider.PCF8574A_0x3F);
 
         // provision gpio input pins from MCP23017

--- a/pi4j-example/src/main/java/PCF8574GpioIrqExample.java
+++ b/pi4j-example/src/main/java/PCF8574GpioIrqExample.java
@@ -1,0 +1,93 @@
+/*
+ * #%L
+ * **********************************************************************
+ * ORGANIZATION  :  Pi4J
+ * PROJECT       :  Pi4J :: Java Examples
+ * FILENAME      :  PCF8574GpioIrqExample.java
+ *
+ * This file is part of the Pi4J project. More information about
+ * this project can be found here:  http://www.pi4j.com/
+ * **********************************************************************
+ * %%
+ * Copyright (C) 2012 - 2017 Pi4J
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
+import com.pi4j.gpio.extension.pcf.PCF8574GpioProvider;
+import com.pi4j.gpio.extension.pcf.PCF8574Pin;
+import com.pi4j.io.gpio.*;
+import com.pi4j.io.gpio.event.GpioPinListenerDigital;
+import com.pi4j.io.i2c.I2CBus;
+import com.pi4j.io.i2c.I2CFactory.UnsupportedBusNumberException;
+
+import java.io.IOException;
+
+/**
+ * <p>The PCF8574 is connected via I2C connection to the Raspberry Pi and provides
+ * 8 GPIO pins that can be used for either digital input or digital output pins.
+ * </p>
+ * <p>
+ * The IRQ output on PCF8574 is connected on GPIO_01
+ * </p>
+ *
+ * @author Gregory DEPUILLE
+ */
+public class PCF8574GpioIrqExample {
+
+    public static void main(String args[]) throws InterruptedException, UnsupportedBusNumberException, IOException {
+
+        System.out.println("<--Pi4J--> PCF8574 GPIO with interrupt on GPIO input Example ... started.");
+
+        // create gpio controller
+        final GpioController gpio = GpioFactory.getInstance();
+        GpioPinDigitalInput irqPin = gpio.provisionDigitalInputPin(RaspiPin.GPIO_01);
+
+        // create custom PCF8574 GPIO provider
+        final PCF8574GpioProvider provider = new PCF8574GpioProvider(I2CBus.BUS_1, PCF8574GpioProvider.PCF8574A_0x38, irqPin);
+
+        // provision gpio input pins from PCF8574
+        GpioPinDigitalInput in0 = gpio.provisionDigitalInputPin(provider, PCF8574Pin.GPIO_00);
+        GpioPinDigitalInput in1 = gpio.provisionDigitalInputPin(provider, PCF8574Pin.GPIO_01);
+        GpioPinDigitalInput in2 = gpio.provisionDigitalInputPin(provider, PCF8574Pin.GPIO_02);
+
+        // create and register gpio pin listener
+        GpioPinListenerDigital l = (event) -> System.out.println(" --> GPIO PIN STATE CHANGE: " + event.getPin() + " = " + event.getState());
+        gpio.addListener(l, in0, in1, in2);
+
+        // provision gpio output pins and make sure they are all LOW at startup
+        GpioPinDigitalOutput out5 = gpio.provisionDigitalOutputPin(provider, PCF8574Pin.GPIO_05, PinState.LOW);
+        GpioPinDigitalOutput out6 = gpio.provisionDigitalOutputPin(provider, PCF8574Pin.GPIO_06, PinState.LOW);
+        GpioPinDigitalOutput out7 = gpio.provisionDigitalOutputPin(provider, PCF8574Pin.GPIO_07, PinState.LOW);
+
+        // on program shutdown, set the pins back to their default state: HIGH
+        gpio.setShutdownOptions(true, PinState.HIGH, out5, out6, out7);
+
+        // keep program running for 30 seconds
+        for (int count = 0; count < 30; count++) {
+            out5.setState(count % 2 > 0);
+            out6.setState(count % 3 > 0);
+            out7.setState(count % 4 > 0);
+            Thread.sleep(1000);
+        }
+
+        // stop all GPIO activity/threads by shutting down the GPIO controller
+        // (this method will forcefully shutdown all GPIO monitoring threads and scheduled tasks)
+        gpio.shutdown();
+
+        System.out.println("Exiting PCF8574GpioIrqExample");
+    }
+}

--- a/pi4j-gpio-extension/pom.xml
+++ b/pi4j-gpio-extension/pom.xml
@@ -14,6 +14,12 @@
 	<!-- PROJECT DEPENDENCIES -->
 	<dependencies>
 		<dependency>
+			<groupId>org.projectlombok</groupId>
+			<artifactId>lombok</artifactId>
+			<scope>provided</scope>
+		</dependency>
+
+		<dependency>
 			<groupId>com.pi4j</groupId>
 			<artifactId>pi4j-core</artifactId>
 			<version>${project.version}</version>

--- a/pi4j-gpio-extension/src/main/java/com/pi4j/gpio/extension/base/MonitorGpioProvider.java
+++ b/pi4j-gpio-extension/src/main/java/com/pi4j/gpio/extension/base/MonitorGpioProvider.java
@@ -1,0 +1,42 @@
+package com.pi4j.gpio.extension.base;
+
+/*-
+ * #%L
+ * **********************************************************************
+ * ORGANIZATION  :  Pi4J
+ * PROJECT       :  Pi4J :: GPIO Extension
+ * FILENAME      :  MonitorGpioProvider.java
+ *
+ * This file is part of the Pi4J project. More information about
+ * this project can be found here:  http://www.pi4j.com/
+ * **********************************************************************
+ * %%
+ * Copyright (C) 2012 - 2017 Pi4J
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
+import com.pi4j.io.gpio.GpioProvider;
+
+/**
+ * <p>
+ * This interface extends the GpioProvider to introduces the monitoring capabilities.
+ * </p>
+ *
+ * @author Gregory DEPUILLE.
+ */
+public interface MonitorGpioProvider extends GpioProvider {
+}

--- a/pi4j-gpio-extension/src/main/java/com/pi4j/gpio/extension/base/MonitorGpioProviderBase.java
+++ b/pi4j-gpio-extension/src/main/java/com/pi4j/gpio/extension/base/MonitorGpioProviderBase.java
@@ -1,0 +1,81 @@
+package com.pi4j.gpio.extension.base;
+
+/*-
+ * #%L
+ * **********************************************************************
+ * ORGANIZATION  :  Pi4J
+ * PROJECT       :  Pi4J :: GPIO Extension
+ * FILENAME      :  MonitorGpioProviderBase.java
+ *
+ * This file is part of the Pi4J project. More information about
+ * this project can be found here:  http://www.pi4j.com/
+ * **********************************************************************
+ * %%
+ * Copyright (C) 2012 - 2017 Pi4J
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
+import com.pi4j.io.gpio.GpioProviderBase;
+
+/**
+ * <p>
+ * This base GPIO provider defined the required interfaces and implements the base functionality for
+ * monitor when an input has changed on external pins.
+ * </p>
+ *
+ * <p>
+ * The monitoring will be disabled, time based or controled from a main input on board.
+ * </p>
+ *
+ * @author Gregory DEPUILLE
+ */
+public abstract class MonitorGpioProviderBase extends GpioProviderBase implements MonitorGpioProvider {
+
+    protected MonitoringStateDevice monitor;
+
+    /**
+     * This method will be overrided by subclass to provide specific clean on shutdown.
+     *
+     * @throws Exception An exception may be raised (cf subclass)
+     */
+    protected void specificShutdown() throws Exception {
+        // NOOP. Will be defined in subclass if needed
+    }
+
+    @Override
+    public void shutdown() {
+        // prevent reentrant invocation
+        if(isShutdown())
+            return;
+
+        // perform shutdown login in base
+        super.shutdown();
+
+        // if a monitor is running, then shut it down now
+        if (monitor != null) {
+            // shutdown monitoring thread
+            monitor.shutdown();
+            monitor = null;
+        }
+
+        try {
+            specificShutdown();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/pi4j-gpio-extension/src/main/java/com/pi4j/gpio/extension/base/MonitoringStateDevice.java
+++ b/pi4j-gpio-extension/src/main/java/com/pi4j/gpio/extension/base/MonitoringStateDevice.java
@@ -1,0 +1,48 @@
+package com.pi4j.gpio.extension.base;
+
+/*-
+ * #%L
+ * **********************************************************************
+ * ORGANIZATION  :  Pi4J
+ * PROJECT       :  Pi4J :: GPIO Extension
+ * FILENAME      :  MonitoringStateDevice.java
+ *
+ * This file is part of the Pi4J project. More information about
+ * this project can be found here:  http://www.pi4j.com/
+ * **********************************************************************
+ * %%
+ * Copyright (C) 2012 - 2017 Pi4J
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
+import java.util.concurrent.TimeUnit;
+
+/**
+ * <p>
+ * This interface defines the contract to implement a Thread to monitor GPIO Provider
+ * </p>
+ *
+ * @author Gregory DEPUILLE
+ */
+public interface MonitoringStateDevice extends Runnable {
+
+    void shutdown();
+
+    long getWaitTime();
+    void setWaitTime(long waitTimeMs);
+    void setWaitTime(long waitTime, TimeUnit unit);
+}

--- a/pi4j-gpio-extension/src/main/java/com/pi4j/gpio/extension/base/MonitoringStateDeviceBase.java
+++ b/pi4j-gpio-extension/src/main/java/com/pi4j/gpio/extension/base/MonitoringStateDeviceBase.java
@@ -1,0 +1,116 @@
+package com.pi4j.gpio.extension.base;
+
+/*-
+ * #%L
+ * **********************************************************************
+ * ORGANIZATION  :  Pi4J
+ * PROJECT       :  Pi4J :: GPIO Extension
+ * FILENAME      :  MonitoringStateDeviceBase.java
+ *
+ * This file is part of the Pi4J project. More information about
+ * this project can be found here:  http://www.pi4j.com/
+ * **********************************************************************
+ * %%
+ * Copyright (C) 2012 - 2017 Pi4J
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
+import com.pi4j.io.gpio.GpioPinDigital;
+import lombok.AccessLevel;
+import lombok.Getter;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * <p>
+ * Base class/thread to monitor actively GPIO Provider.
+ * </p>
+ *
+ * @author Robert Savage (initial thread for PCF8574 and ADS1x15)
+ * @author Gregory DEPUILLE
+ */
+public abstract class MonitoringStateDeviceBase<D, P extends GpioPinDigital> extends Thread implements MonitoringStateDevice {
+
+    @Getter(AccessLevel.PROTECTED)
+    private final D device;
+
+    @Getter(AccessLevel.PROTECTED)
+    private P irqPin = null;
+
+    private boolean shuttingDown = false;
+
+    @Getter
+    private long waitTime = 50;
+
+    protected abstract boolean irqRead();
+    protected abstract void doRead() throws IOException;
+
+    protected MonitoringStateDeviceBase(D device) {
+        this.device = device;
+    }
+
+    protected MonitoringStateDeviceBase(D device, P irqPin) {
+        this(device);
+        this.irqPin = irqPin;
+    }
+
+    protected MonitoringStateDeviceBase(D device, P irqPin, long waitTimeMs) {
+        this(device, irqPin);
+        waitTime = waitTimeMs;
+    }
+
+    protected MonitoringStateDeviceBase(D device, P irqPin, long waitTime, TimeUnit unit) {
+        this(device, irqPin);
+        this.waitTime = unit.toMillis(waitTime);
+    }
+
+    @Override
+    public void setWaitTime(long waitTimeMs) {
+        this.waitTime = waitTimeMs;
+    }
+
+    @Override
+    public void setWaitTime(long waitTime, TimeUnit unit) {
+        this.waitTime = unit.toMillis(waitTime);
+    }
+
+    @Override
+    public final void shutdown() {
+        shuttingDown = true;
+    }
+
+    @Override
+    public final void run() {
+        while (!shuttingDown) {
+            try {
+                // read device pins state.
+                // if an IRQ pin is registered, read only if an interruption is read
+                // /!\ Usage of IRQ pin isn't compatible when the same pin is used for more than 1 device
+                if (irqPin == null || irqRead()) {
+                    doRead();
+                }
+
+                // ... lets take a short breather ...
+                Thread.currentThread();
+                Thread.sleep(waitTime);
+            } catch (Exception ex) {
+                ex.printStackTrace();
+            }
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -206,6 +206,7 @@
         <!-- DEPENDENCY VERSIONS -->
         <org.osgi.core.version>6.0.0</org.osgi.core.version>
         <ant-jsch.version>1.9.7</ant-jsch.version>
+        <lombok.version>1.16.16</lombok.version>
         <jsch.version>0.1.53</jsch.version>
         <ant-contrib.version>20020829</ant-contrib.version>
         <junit.version>4.12</junit.version>
@@ -269,6 +270,12 @@
                 <groupId>ant-contrib</groupId>
                 <artifactId>ant-contrib</artifactId>
                 <version>${ant-contrib.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.projectlombok</groupId>
+                <artifactId>lombok</artifactId>
+                <version>${lombok.version}</version>
+                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>junit</groupId>


### PR DESCRIPTION
Hi,
I open this PR to adress an improvements to detect the modification on a GPIO Provider I2C (like PCF8574)

I have refactored and centralized the monitoring thread include in PCF8574GpioProvider and ADS1x15GpioProvider.
Now, like before, the thread check regularly if an input has changed. This will be detected when a native GPIO pin are in a specific state. 
In order to allow the possibility to use more than one device use the same IRQ input (PCF8574 has an open drain interrupt output), it's possible to disabled monitoring thread. 
I have implemented an exemple for the PCF8574 (I have it) to valid all the use case. But I haven't the ADS1x15, and I have not tested on this one.

When I realized some tests I have to meet a bug when the PCF8574 is used with inputs and outputs. The documentation says to define a line as an input a high level will be write to the single register. I have fix that with an output mask to store the input pins.
