### PR TITLE
Newer and explicit licence-maven-plugin version

### DIFF
--- a/pi4j-native/src/main/native/com_pi4j_wiringpi_GpioInterrupt.c
+++ b/pi4j-native/src/main/native/com_pi4j_wiringpi_GpioInterrupt.c
@@ -135,6 +135,9 @@ int monitorPinInterrupt(void *threadarg)
 	int compareLastKnown = strncmp(rdbuf, "1", 1); // only compare the first character; rdbuff may have more junk chars
 	monitorData->lastKnownState = compareLastKnown;
 
+JNIEnv *env;
+					(*gpio_callback_jvm)->AttachCurrentThread(gpio_callback_jvm, (void **)&env, NULL);
+
 	// continuous thread loop
 	for(;;)
 	{
@@ -192,8 +195,7 @@ int monitorPinInterrupt(void *threadarg)
 				if (gpio_callback_class != NULL && gpio_callback_method != NULL)
 				{
 					// get attached JVM
-					JNIEnv *env;
-					(*gpio_callback_jvm)->AttachCurrentThread(gpio_callback_jvm, (void **)&env, NULL);
+					
 
 					// ensure that the JVM exists
 					if(gpio_callback_jvm != NULL)
@@ -206,7 +208,7 @@ int monitorPinInterrupt(void *threadarg)
 					}
 
                     // detach from thread
-                    (*gpio_callback_jvm)->DetachCurrentThread(gpio_callback_jvm);
+                    //(*gpio_callback_jvm)->DetachCurrentThread(gpio_callback_jvm);
 				}
 			}
 		}

--- a/pom.xml
+++ b/pom.xml
@@ -225,7 +225,7 @@
         <maven-bundle-plugin.version>3.2.0</maven-bundle-plugin.version>
         <maven-antrun-plugin.version>1.8</maven-antrun-plugin.version>
         <native-maven-plugin.version>1.0-alpha-8</native-maven-plugin.version>
-        <license-maven-plugin.version>1.12</license-maven-plugin.version>
+        <license-maven-plugin.version>1.14</license-maven-plugin.version>
         <build-helper-maven-plugin.version>3.0.0</build-helper-maven-plugin.version>
         <site-maven-plugin.version>0.12</site-maven-plugin.version>
         <jdeb.version>1.5</jdeb.version>
@@ -886,6 +886,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>license-maven-plugin</artifactId>
+                <version>${license-maven-plugin.version}</version>
 				<executions>
 					<execution>
 						<id>update-project-license</id>


### PR DESCRIPTION
Make build more stable by specifying licence-maven-plugin version and bumping current explicit version.

I was getting mangled source due to picking up random versions of the plugin. Making it match the other usage caused other problems so I've now pegged them both to the latest version.