### PR TITLE
Avoid useless file changes after build

### DIFF
--- a/pi4j-gpio-extension/src/main/native/olimex/avrio-m16/OlimexAvrIoM16-Pi4JGpioExtension.c
+++ b/pi4j-gpio-extension/src/main/native/olimex/avrio-m16/OlimexAvrIoM16-Pi4JGpioExtension.c
@@ -4,7 +4,7 @@
  * ORGANIZATION  :  Pi4J
  * PROJECT       :  Pi4J :: GPIO Extension
  * FILENAME      :  OlimexAvrIoM16-Pi4JGpioExtension.c
- * 
+ *
  * This file is part of the Pi4J project. More information about
  * this project can be found here:  http://www.pi4j.com/
  * **********************************************************************

--- a/src/license/template.ftl
+++ b/src/license/template.ftl
@@ -1,8 +1,8 @@
-**********************************************************************
-ORGANIZATION  :  ${organizationName}
-PROJECT       :  ${projectName}
-FILENAME      :  ${file.name}
-
-This file is part of the Pi4J project. More information about
-this project can be found here:  http://www.pi4j.com/
-**********************************************************************
+ **********************************************************************
+ * ORGANIZATION  :  ${organizationName}
+ * PROJECT       :  ${projectName}
+ * FILENAME      :  ${file.name}
+ *
+ * This file is part of the Pi4J project. More information about
+ * this project can be found here:  http://www.pi4j.com/
+ * **********************************************************************


### PR DESCRIPTION
The template "template.ftl" causes useless file differences after a maven build, leading to all files having so-called changes.  This makes it difficult, if not impossible, to see the real and important file changes.
Template file is modified to avoid those useless changes in comment parts only.