### PR TITLE
Simulated Platform to aid development

### DIFF
--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/SimulatedGpioProvider.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/SimulatedGpioProvider.java
@@ -2,11 +2,34 @@ package com.pi4j.io.gpio;
 
 import java.util.Map;
 
-public class SimulatedGpioProvider extends GpioProviderBase implements GpioProvider {
 
-   // public static final String NAME = "Simulator GPIO Provider";
+/**
+ * A simulator to aid in development of RI Pi systems using a standard PC dev environment.
+ * 
+ * To use the simulator you need two environment variables:
+ * 
+ * The standard PI4J platform statement MUST point to the simulator:
+ * 
+ * PI4J_PLATFORM=Simulated
+ * 
+ * A second environment variable that defines the platform that is to be simulated.
+ * 
+ * SimulatedPlatform=<Real Platform's Name>
+ * 
+ * e.g.
+ * 
+ * SimultatedPlatform=RaspberryPi GPIO Provider
+ * 
+ * If you don't provide a value for theSimulatedPlatform the system assumes that you want to use
+ * the raspberry pi platform: RaspiGpioProvider
+ * 
+ * @author bsutton
+ *
+ */
+public class SimulatedGpioProvider extends GpioProviderBase implements GpioProvider {
 	
-	public static String NAME;
+	// We use the name of the platform that we are simulating.
+    public static  String NAME;
 	
 	public SimulatedGpioProvider()
 	{
@@ -17,22 +40,8 @@ public class SimulatedGpioProvider extends GpioProviderBase implements GpioProvi
 		 // If no specific platform is specified we default to simulating the raspberry pi.
 		 if (config == null)
 			 NAME=RaspiGpioProvider.NAME;
-		 
-//		 try
-//		{
-//			Class<GpioProvider> providerClass = (Class<GpioProvider>) Class.forName(config);
-//			provider
-//			
-//		}
-//		catch (ClassNotFoundException e)
-//		{
-//			// TODO Auto-generated catch block
-//			e.printStackTrace();
-//		}
-		 
+	 
 		 NAME = config;
-		 
-		 
 	}
 
     @Override

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/SimulatedGpioProvider.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/SimulatedGpioProvider.java
@@ -2,9 +2,39 @@ package com.pi4j.io.gpio;
 
 import java.util.Map;
 
+/*
+ * #%L
+ * **********************************************************************
+ * ORGANIZATION  :  Pi4J
+ * PROJECT       :  Pi4J :: Java Library (Core)
+ * FILENAME      :  RCMPin.java
+ *
+ * This file is part of the Pi4J project. More information about
+ * this project can be found here:  http://www.pi4j.com/
+ * **********************************************************************
+ * %%
+ * Copyright (C) 2012 - 2017 Pi4J
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
 
 /**
- * A simulator to aid in development of RI Pi systems using a standard PC dev environment.
+ * A simulator to aid in development of RI Pi systems using a standard PC dev
+ * environment.
  * 
  * To use the simulator you need two environment variables:
  * 
@@ -12,7 +42,8 @@ import java.util.Map;
  * 
  * PI4J_PLATFORM=Simulated
  * 
- * A second environment variable that defines the platform that is to be simulated.
+ * A second environment variable that defines the platform that is to be
+ * simulated.
  * 
  * SimulatedPlatform=<Real Platform's Name>
  * 
@@ -20,33 +51,33 @@ import java.util.Map;
  * 
  * SimultatedPlatform=RaspberryPi GPIO Provider
  * 
- * If you don't provide a value for theSimulatedPlatform the system assumes that you want to use
- * the raspberry pi platform: RaspiGpioProvider
+ * If you don't provide a value for theSimulatedPlatform the system assumes that
+ * you want to use the raspberry pi platform: RaspiGpioProvider
  * 
  * @author bsutton
  *
  */
 public class SimulatedGpioProvider extends GpioProviderBase implements GpioProvider {
-	
-	// We use the name of the platform that we are simulating.
-    public static  String NAME;
-	
-	public SimulatedGpioProvider()
-	{
-		 Map<String, String> env = System.getenv();
-		 
-		 String config = env.get("SimulatedPlatform");
-		 
-		 // If no specific platform is specified we default to simulating the raspberry pi.
-		 if (config == null)
-			 NAME=RaspiGpioProvider.NAME;
-	 
-		 NAME = config;
-	}
+
+    // We use the name of the platform that we are simulating.
+    public static String NAME;
+
+    public SimulatedGpioProvider() {
+        Map<String, String> env = System.getenv();
+
+        String config = env.get("SimulatedPlatform");
+
+        // If no specific platform is specified we default to simulating the raspberry
+        // pi.
+        if (config == null)
+            NAME = RaspiGpioProvider.NAME;
+
+        NAME = config;
+    }
 
     @Override
     public String getName() {
-    	
+
         return NAME;
     }
 

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/SimulatedGpioProvider.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/SimulatedGpioProvider.java
@@ -1,0 +1,60 @@
+package com.pi4j.io.gpio;
+
+import java.util.Map;
+
+public class SimulatedGpioProvider extends GpioProviderBase implements GpioProvider {
+
+   // public static final String NAME = "Simulator GPIO Provider";
+	
+	public static String NAME;
+	
+	public SimulatedGpioProvider()
+	{
+		 Map<String, String> env = System.getenv();
+		 
+		 String config = env.get("SimulatedPlatform");
+		 
+		 // If no specific platform is specified we default to simulating the raspberry pi.
+		 if (config == null)
+			 NAME=RaspiGpioProvider.NAME;
+		 
+//		 try
+//		{
+//			Class<GpioProvider> providerClass = (Class<GpioProvider>) Class.forName(config);
+//			provider
+//			
+//		}
+//		catch (ClassNotFoundException e)
+//		{
+//			// TODO Auto-generated catch block
+//			e.printStackTrace();
+//		}
+		 
+		 NAME = config;
+		 
+		 
+	}
+
+    @Override
+    public String getName() {
+    	
+        return NAME;
+    }
+
+    public void setState(Pin pin, PinState state) {
+        // cache pin state
+        getPinCache(pin).setState(state);
+
+        // dispatch event
+        dispatchPinDigitalStateChangeEvent(pin, state);
+    }
+
+    public void setAnalogValue(Pin pin, double value) {
+        // cache pin state
+        getPinCache(pin).setAnalogValue(value);
+
+        // dispatch event
+        dispatchPinAnalogValueChangeEvent(pin, value);
+    }
+
+}

--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/SimulatedGpioProvider.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/SimulatedGpioProvider.java
@@ -2,11 +2,37 @@ package com.pi4j.io.gpio;
 
 import java.util.Map;
 
-public class SimulatedGpioProvider extends GpioProviderBase implements GpioProvider {
 
-   // public static final String NAME = "Simulator GPIO Provider";
+/**
+ * A simulator to aid in development of RI Pi systems using a standard PC dev environment.
+ * 
+ * To use the simulator you need two environment variables:
+ * 
+ * The standard PI4J platform statement MUST point to the simulator:
+ * 
+ * PI4J_PLATFORM=Simulated
+ * 
+ * A second environment variable that defines the platform that is to be simulated.
+ * 
+ * SimulatedPlatform=<Real Platform's Name>
+ * 
+ * e.g.
+ * 
+ * SimultatedPlatform=RaspberryPi GPIO Provider
+ * 
+ * If you don't provide a value for theSimulatedPlatform the system assumes that you want to use
+ * the raspberry pi platform: RaspiGpioProvider
+ * 
+ * @author bsutton
+ *
+ */
+public class SimulatedGpioProvider extends GpioProviderBase implements GpioProvider {
 	
-	public static String NAME;
+	
+	
+
+	// We use the name of the platform that we are simulating.
+    public static  String NAME;
 	
 	public SimulatedGpioProvider()
 	{
@@ -17,22 +43,8 @@ public class SimulatedGpioProvider extends GpioProviderBase implements GpioProvi
 		 // If no specific platform is specified we default to simulating the raspberry pi.
 		 if (config == null)
 			 NAME=RaspiGpioProvider.NAME;
-		 
-//		 try
-//		{
-//			Class<GpioProvider> providerClass = (Class<GpioProvider>) Class.forName(config);
-//			provider
-//			
-//		}
-//		catch (ClassNotFoundException e)
-//		{
-//			// TODO Auto-generated catch block
-//			e.printStackTrace();
-//		}
-		 
+	 
 		 NAME = config;
-		 
-		 
 	}
 
     @Override

--- a/pi4j-core/src/main/java/com/pi4j/platform/Platform.java
+++ b/pi4j-core/src/main/java/com/pi4j/platform/Platform.java
@@ -52,7 +52,8 @@ public enum Platform {
     BPI("bpi", "Synovoip BPI"),
     ODROID("odroid", "Odroid"),
     ORANGEPI("orangepi", "OrangePi"),
-    NANOPI("nanopi", "NanoPi");
+    NANOPI("nanopi", "NanoPi"),
+	SIMULATED("simulated", "Simulated");
 
     // private variables
     protected String platformId = null;
@@ -141,7 +142,10 @@ public enum Platform {
             case NANOPI: {
                 return new NanoPiGpioProvider();
             }
-            default: {
+            case SIMULATED: {
+                return new SimulatedGpioProvider();
+            }
+          default: {
                 // if a platform cannot be determine, then assume it's the default RaspberryPi
                 return new RaspiGpioProvider();
             }

--- a/pi4j-core/src/main/java/com/pi4j/platform/Platform.java
+++ b/pi4j-core/src/main/java/com/pi4j/platform/Platform.java
@@ -53,7 +53,7 @@ public enum Platform {
     ODROID("odroid", "Odroid"),
     ORANGEPI("orangepi", "OrangePi"),
     NANOPI("nanopi", "NanoPi"),
-	SIMULATED("simulated", "Simulated");
+    SIMULATED("simulated", "Simulated");
 
     // private variables
     protected String platformId = null;


### PR DESCRIPTION
I've created a simulated platform that mimics any of the existing platforms (at a very basic level) to allow development on a standard PC platform.

To use the simulator you need two environment variables:
The standard PI4J platform statement MUST point to the simulator:
`PI4J_PLATFORM=Simulated`

A second environment variable that defines the platform that is to be simulated.
`SimulatedPlatform=<Real Platform's Name>`

e.g.
`SimultatedPlatform=RaspberryPi GPIO Provider`


