### PR TITLE
Avoid NPE in GpioControllerImpl when provisioning new Pins with SimulatedGpioProvider.

### DIFF
--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/impl/GpioControllerImpl.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/impl/GpioControllerImpl.java
@@ -77,7 +77,7 @@ public class GpioControllerImpl implements GpioController {
     @Override
     public GpioPin getProvisionedPin(Pin pin){
         for(GpioPin gpio_pin : pins){
-            if(gpio_pin.getPin().equals(pin)){
+            if (Objects.equals(gpio_pin.getPin(), pin)) {
                 return gpio_pin;
             }
         }
@@ -87,7 +87,7 @@ public class GpioControllerImpl implements GpioController {
     @Override
     public GpioPin getProvisionedPin(String name){
         for(GpioPin pin : pins){
-            if(pin.getName().equals(name)){
+            if (Objects.equals(pin.getName(), name)) {
                 return pin;
             }
         }
@@ -543,13 +543,13 @@ public class GpioControllerImpl implements GpioController {
     public GpioPin provisionPin(GpioProvider provider, Pin pin, String name, PinMode mode, PinState defaultState) {
 
         // if the provider does not match the pin's provider then throw an error
-        if(!provider.getName().equals(pin.getProvider())){
+        if (!Objects.equals(provider.getName(), pin.getProvider())) {
             throw new PinProviderException(provider, pin);
         }
 
         // if an existing pin has been previously created, then throw an error
         for(GpioPin p : pins) {
-            if (p.getProvider().equals(provider) && p.getPin().equals(pin)) {
+            if (Objects.equals(p.getProvider(), provider) && Objects.equals(p.getPin(), pin)) {
                 throw new GpioPinExistsException(pin);
             }
         }

--- a/pi4j-core/src/test/java/com/pi4j/io/gpio/impl/GpioControllerImplTest.java
+++ b/pi4j-core/src/test/java/com/pi4j/io/gpio/impl/GpioControllerImplTest.java
@@ -1,0 +1,53 @@
+package com.pi4j.io.gpio.impl;
+
+/*-
+ * #%L
+ * **********************************************************************
+ * ORGANIZATION  :  Pi4J
+ * PROJECT       :  Pi4J :: Java Library (Core)
+ * FILENAME      :  GpioControllerImplTest.java
+ *
+ * This file is part of the Pi4J project. More information about
+ * this project can be found here:  http://www.pi4j.com/
+ * **********************************************************************
+ * %%
+ * Copyright (C) 2012 - 2018 Pi4J
+ * %%
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation, either version 3 of the
+ * License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Lesser Public License for more details.
+ *
+ * You should have received a copy of the GNU General Lesser Public
+ * License along with this program.  If not, see
+ * <http://www.gnu.org/licenses/lgpl-3.0.html>.
+ * #L%
+ */
+
+import com.pi4j.io.gpio.*;
+import com.pi4j.io.gpio.exception.PinProviderException;
+import org.junit.Before;
+import org.junit.Test;
+
+/**
+ * Unit test for the {@link GpioControllerImpl}.
+ */
+public class GpioControllerImplTest {
+    @Before
+    public void setUp() {
+        GpioProvider provider = new SimulatedGpioProvider();
+        GpioFactory.setDefaultProvider(provider);
+    }
+
+    @Test(expected = PinProviderException.class)
+    public void testProvisionPin() {
+        GpioController controller = new GpioControllerImpl();
+
+        controller.provisionPin(RaspiPin.GPIO_00, PinMode.DIGITAL_OUTPUT);
+    }
+}


### PR DESCRIPTION
This PR avoids `NullPointerExceptions` in `GpioControllerImpl` when provisioning new Pins with the `SimulatedGpioProvider`.

It uses `Objects.equals(a,b)` instead `a.equals(b)` to avoid `NullPointerExceptions` if `a` null.