### PR TITLE
Incorrect logic checking for PWM Mode

### DIFF
--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/GpioProviderBase.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/GpioProviderBase.java
@@ -264,7 +264,7 @@ public abstract class GpioProviderBase implements GpioProvider {
 
         PinMode mode = getMode(pin);
 
-        if (mode != PinMode.PWM_OUTPUT || mode != PinMode.SOFT_PWM_OUTPUT) {
+        if (mode != PinMode.PWM_OUTPUT && mode != PinMode.SOFT_PWM_OUTPUT) {
             throw new InvalidPinModeException(pin, "Invalid pin mode [" + mode.getName() + "]; unable to setPwm(" + value + ")");
         }
 


### PR DESCRIPTION
Will always throw throw new InvalidPinModeException
Because to return false for mode != PinMode.PWM_OUTPUT || mode != PinMode.SOFT_PWM_OUTPUT
you would have to both be !=PinMode.PWM_OUTPUT and !=PinMode.SOFT_PWM_OUTPUT