### PR TITLE
add synchronized block to pins iteration

### DIFF
--- a/pi4j-core/src/main/java/com/pi4j/io/gpio/impl/GpioControllerImpl.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/gpio/impl/GpioControllerImpl.java
@@ -548,9 +548,11 @@ public class GpioControllerImpl implements GpioController {
         }
 
         // if an existing pin has been previously created, then throw an error
-        for(GpioPin p : pins) {
-            if (Objects.equals(p.getProvider(), provider) && Objects.equals(p.getPin(), pin)) {
-                throw new GpioPinExistsException(pin);
+        synchronized(pins) {
+            for(GpioPin p : pins) {
+                if (Objects.equals(p.getProvider(), provider) && Objects.equals(p.getPin(), pin)) {
+                    throw new GpioPinExistsException(pin);
+                }
             }
         }
 


### PR DESCRIPTION
As java docs says on Collections.synchronizedList(List<T> list)
"It is imperative that the user manually synchronize on the returned list when iterating over it".