### PR TITLE
Removed exception handling (test smell)

### DIFF
--- a/pi4j-device/src/test/java/com/pi4j/component/potentiometer/microchip/impl/MicrochipPotentiometerDeviceControllerStaticTest.java
+++ b/pi4j-device/src/test/java/com/pi4j/component/potentiometer/microchip/impl/MicrochipPotentiometerDeviceControllerStaticTest.java
@@ -56,21 +56,15 @@ public class MicrochipPotentiometerDeviceControllerStaticTest {
 	@Test
 	public void testCreation() throws IOException {
 
-		// wrong parameter
-
-		try {
-
-			new MicrochipPotentiometerDeviceController(null);
-			fail("Got no RuntimeException on constructing "
-					+ "a DeviceController using a null-i2cDevice");
-
-		} catch (RuntimeException e) {
-			// expected expection
-		}
-
-		// correct parameter
-
 		new MicrochipPotentiometerDeviceController(i2cDevice);
+		assertNotNull(i2cDevice);
+
+	}
+
+	@Test(expected = RuntimeException.class)
+	public void testCreationExceptionNullI2cDevice() throws IOException {
+
+		new MicrochipPotentiometerDeviceController(null);
 
 	}
 


### PR DESCRIPTION
Problem:
The exception handling test smell occurs when a test method explicitly a passing or failing of a test method is dependent on the production method throwing an exception. 

Correction:
I used JUnit's exception handling to automatically pass/fail the test instead of writing custom exception handling code or throwing an exception. The original method generated two new ones: with and without the correct parameter, which must raise an exception.