### PR TITLE
Replace `jdk.internal.misc.SharedSecrets` impl with native JNI method

### DIFF
--- a/pi4j-core/src/main/java/com/pi4j/io/file/LinuxFile.java
+++ b/pi4j-core/src/main/java/com/pi4j/io/file/LinuxFile.java
@@ -27,6 +27,7 @@ package com.pi4j.io.file;
  * #L%
  */
 
+import java.io.FileDescriptor;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.RandomAccessFile;
@@ -36,9 +37,6 @@ import java.nio.ByteOrder;
 import java.nio.IntBuffer;
 
 import com.pi4j.util.NativeLibraryLoader;
-import jdk.internal.misc.SharedSecrets;
-
-// TODO :: REMOVE JDK INTERNAL REFS
 
 /**
  * Extends RandomAccessFile to provide access to Linux ioctl.
@@ -179,7 +177,7 @@ public class LinuxFile extends RandomAccessFile {
      * Gets the real POSIX file descriptor for use by custom jni calls.
      */
     private int getFileDescriptor() throws IOException {
-		final int fd = SharedSecrets.getJavaIOFileDescriptorAccess().get(getFD());
+		final int fd = getPosixFD(getFD());
 
         if(fd < 1)
             throw new IOException("failed to get POSIX file descriptor!");
@@ -273,4 +271,6 @@ public class LinuxFile extends RandomAccessFile {
     protected static native int directIOCTL(int fd, long command, int value);
 
     protected static native int directIOCTLStructure(int fd, long command, ByteBuffer data, int dataOffset, IntBuffer offsetMap, int offsetMapOffset, int offsetCapacity);
+
+    protected static native int getPosixFD(FileDescriptor fileDescriptor);
 }

--- a/pi4j-native/src/main/native/com_pi4j_io_file_LinuxFile.c
+++ b/pi4j-native/src/main/native/com_pi4j_io_file_LinuxFile.c
@@ -137,3 +137,41 @@ int directIOCTLStructure
 
     return ioctl(fd, command, data + headOffset);
 }
+
+
+/*
+ * Class:       com_pi4j_io_file_LinuxFile
+ * Method:      getFD
+ * Signature:   (Ljava.io.FileDescriptor;)I
+ *
+ * Extracts POSIX File Descriptor from a Java FileDescriptor object.
+ */
+JNIEXPORT jint JNICALL Java_com_pi4j_io_file_LinuxFile_getPosixFD
+  (JNIEnv *env, jclass obj, jobject fileDescriptorObj)
+{
+    jfieldID  fdFieldID;
+    jclass    fdClass;
+    int       fd = -1;
+
+    // Get Class and Field information.
+    fdClass = (*env)->FindClass(env, "java/io/FileDescriptor");
+
+    if ( fdClass == NULL )
+    {
+        // Unable to obtain Class information
+        return -2;
+    }
+
+    fdFieldID = (*env)->GetFieldID(env, fdClass, "fd", "I");
+
+    if ( fdFieldID == NULL )
+    {
+        // Unable to obtain Field information
+        return -3;
+    }
+
+    // Extract POSIX File Descriptor from Java FileDescriptor object
+    fd = (*env)->GetIntField(env, fileDescriptorObj, fdFieldID);
+
+    return fd;
+}

--- a/pi4j-native/src/main/native/com_pi4j_io_file_LinuxFile.h
+++ b/pi4j-native/src/main/native/com_pi4j_io_file_LinuxFile.h
@@ -82,6 +82,14 @@ JNIEXPORT jint JNICALL Java_com_pi4j_io_file_LinuxFile_munmapDirect
 JNIEXPORT jint JNICALL Java_com_pi4j_io_file_LinuxFile_directIOCTLStructure
   (JNIEnv *env, jclass obj, jint fd, jlong command, jobject data, jint dataOffset, jobject offsetMap, jint offsetMapOffset, jint offsetCapacity);
 
+/*
+ * Class:      com_pi4j_io_file_LinuxFile
+ * Method:     getFD
+ * Signature:  (Ljava.io.FileDescriptor;)I
+ */
+JNIEXPORT jint JNICALL Java_com_pi4j_io_file_LinuxFile_getPosixFD
+  (  JNIEnv *env, jclass obj, jobject  fileDescriptor );
+
 #ifdef __cplusplus
 }
 #endif

--- a/pom.xml
+++ b/pom.xml
@@ -563,19 +563,9 @@
 					<artifactId>maven-compiler-plugin</artifactId>
 					<version>${maven-compiler-plugin.version}</version>
 					<configuration>
-
-						<!-- TODO :: ENABLE BUILD FOR JDK 11 RELEASE -->
-						<!--<release>${java.version}</release>-->
-
 						<showDeprecation>true</showDeprecation>
 						<showWarnings>true</showWarnings>
 						<verbose>false</verbose>
-
-						<compilerArgs>
-							<!-- TODO :: ELIMINATE JDK INTERNAL REFS -->
-							<arg>--add-exports</arg><arg>java.base/jdk.internal.misc=ALL-UNNAMED</arg>
-							<arg>--add-exports</arg><arg>java.base/jdk.internal.ref=ALL-UNNAMED</arg>
-						</compilerArgs>
 					</configuration>
 				</plugin>
 


### PR DESCRIPTION
Replace `jdk.internal.misc.SharedSecrets` impl with native JNI method `getPosixFD`.

Related Issues:
 - #521 
 - #442
 - #404