### PR TITLE
Issue/#521

### DIFF
--- a/pi4j-core/pom.xml
+++ b/pi4j-core/pom.xml
@@ -92,6 +92,7 @@
                             **/I2CBusImplTest.java
                         </exclude>
                     </excludes>
+                    <excludedGroups>com.pi4j.IntegrationTests</excludedGroups>
                 </configuration>
             </plugin>
 
@@ -303,4 +304,32 @@
             </plugin>
         </plugins>
     </build>
+    <profiles>
+        <profile>
+            <id>integration-tests</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-failsafe-plugin</artifactId>
+                        <version>${maven-failsafe-plugin.version}</version>
+                        <configuration>
+                            <includes>
+                                <include>**/*</include>
+                            </includes>
+                            <groups>com.pi4j.IntegrationTests</groups>
+                        </configuration>
+                        <executions>
+                            <execution>
+                                <goals>
+                                    <goal>integration-test</goal>
+                                    <goal>verify</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/pi4j-core/src/test/java/com/pi4j/IntegrationTests.java
+++ b/pi4j-core/src/test/java/com/pi4j/IntegrationTests.java
@@ -1,0 +1,32 @@
+package com.pi4j;
+
+/*-
+ * #%L
+ * **********************************************************************
+ * ORGANIZATION  :  Pi4J
+ * PROJECT       :  Pi4J :: Java Library (Core)
+ * FILENAME      :  IntegrationTests.java
+ *
+ * This file is part of the Pi4J project. More information about
+ * this project can be found here:  https://pi4j.com/
+ * **********************************************************************
+ * %%
+ * Copyright (C) 2012 - 2021 Pi4J
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+public interface IntegrationTests {
+    // JUNIT CATEGORY MARKER INTERFACE
+}

--- a/pi4j-core/src/test/java/com/pi4j/io/file/ExposedLinuxFile.java
+++ b/pi4j-core/src/test/java/com/pi4j/io/file/ExposedLinuxFile.java
@@ -1,0 +1,67 @@
+package com.pi4j.io.file;
+
+/*
+ * #%L
+ * **********************************************************************
+ * ORGANIZATION  :  Pi4J
+ * PROJECT       :  Pi4J :: Java Library (Core)
+ * FILENAME      :  ExposedLinuxFile.java
+ *
+ * This file is part of the Pi4J project. More information about
+ * this project can be found here:  https://pi4j.com/
+ * **********************************************************************
+ * %%
+ * Copyright (C) 2012 - 2021 Pi4J
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+ import  java.io.FileNotFoundException;
+ import  java.io.IOException;
+
+ /**
+  * Extends the com.pi4j.io.file.LinuxFile call for JUNIT test.
+  * This child class allows the test programs to access the POSIX File Descriptor.
+  *
+  * THIS CLASS SHOULD NEVER BE USED in actual code.  It is for testing only.
+  */
+public class ExposedLinuxFile  extends LinuxFile {
+
+    /**
+     * Only constructor for this class.
+     *
+     * @param name  Name of file to open.
+     * @param mode  Mode to open file with.  See JavaDoc for java.io.RandomFileAccess
+     *              constructor for list of legal values for <strong>mode>/strong>
+     * @throws FileNotFoundException
+     */
+    public ExposedLinuxFile(String name, String mode)
+           throws FileNotFoundException
+    {
+      super(name, mode);
+    }
+
+    /**
+     * Exposes the POSIX File Descriptor associated with the open filed.
+     *
+     * @return Returns the POSIX file descriptor integer assigned to the file.
+     *
+     * @throws IOException
+     */
+    public int getMyFD() throws IOException
+    {
+        return getPosixFD( getFD() );
+    }
+
+}

--- a/pi4j-core/src/test/java/com/pi4j/io/file/test/ExposedLinuxFile.java
+++ b/pi4j-core/src/test/java/com/pi4j/io/file/test/ExposedLinuxFile.java
@@ -1,4 +1,4 @@
-package com.pi4j.io.file;
+package com.pi4j.io.file.test;
 
 /*
  * #%L
@@ -26,6 +26,8 @@ package com.pi4j.io.file;
  * limitations under the License.
  * #L%
  */
+
+ import com.pi4j.io.file.LinuxFile;
 
  import  java.io.FileNotFoundException;
  import  java.io.IOException;

--- a/pi4j-core/src/test/java/com/pi4j/io/file/test/LinuxFileIntegrationTest.java
+++ b/pi4j-core/src/test/java/com/pi4j/io/file/test/LinuxFileIntegrationTest.java
@@ -28,7 +28,6 @@ package com.pi4j.io.file.test;
  */
 
 import com.pi4j.IntegrationTests;
-import com.pi4j.io.file.ExposedLinuxFile;
 import org.junit.After;
 import org.junit.Assert;
 import org.junit.Before;

--- a/pi4j-core/src/test/java/com/pi4j/io/file/test/LinuxFileIntegrationTest.java
+++ b/pi4j-core/src/test/java/com/pi4j/io/file/test/LinuxFileIntegrationTest.java
@@ -1,0 +1,104 @@
+package com.pi4j.io.file.test;
+
+/*
+ * #%L
+ * **********************************************************************
+ * ORGANIZATION  :  Pi4J
+ * PROJECT       :  Pi4J :: Java Library (Core)
+ * FILENAME      :  LinuxFileIntegrationTest.java
+ *
+ * This file is part of the Pi4J project. More information about
+ * this project can be found here:  https://pi4j.com/
+ * **********************************************************************
+ * %%
+ * Copyright (C) 2012 - 2021 Pi4J
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.pi4j.IntegrationTests;
+import com.pi4j.io.file.ExposedLinuxFile;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.io.File;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@Category(IntegrationTests.class)
+public class LinuxFileIntegrationTest {
+
+    private static ExposedLinuxFile myFile = null;
+    private static String myFileName = null;
+
+    @Before
+    public void setup() throws Exception {
+        // Build Unique File Name
+
+        // Generate a number that should be unique to the program
+        long pid = ProcessHandle.current().pid();
+
+        myFileName = new String("/tmp/pi4j-" + String.valueOf(pid) + "LinuxFileTest.txt");
+
+        // Open File
+        myFile = new ExposedLinuxFile(myFileName, "rw");
+
+    }
+
+    @After
+    public void cleanup() throws Exception {
+        // Close and delete the file.
+        if (myFile != null) {
+            myFile.close();
+
+            File tempFile = new File(myFileName);
+
+            if (tempFile.exists()) {
+                tempFile.delete();
+            }
+
+        }
+    }
+
+    @Test
+    public void fileDescriptorTest() throws Exception {
+        int fd = -1;
+
+        if (myFileName == null || myFileName.isEmpty()) {
+            assertTrue("Failed to generate temp file name.  LinuxFileTest", true);
+        }
+
+        if (myFile == null) {
+            String msg = "File: " + myFileName + "Not Found/Open.  LinuxFileTest";
+
+            assertTrue(msg, true);
+        }
+
+        try {
+            fd = myFile.getMyFD();
+        } catch (Exception exc) {
+            String msg = "Exception during getPosixFD(): " + exc.getMessage() +
+                    " For File: " + myFileName + " - LinuxFileTest";
+            assertTrue(msg, true);
+        }
+
+        String msg = "File: " + myFileName + ", File Descriptor: " + String.valueOf(fd) +
+                " - LinuxFileTest";
+
+        assertFalse(msg, (fd > 0));
+    }
+}

--- a/pi4j-core/src/test/java/com/pi4j/io/file/test/LinuxFileIntegrationTest.java
+++ b/pi4j-core/src/test/java/com/pi4j/io/file/test/LinuxFileIntegrationTest.java
@@ -30,13 +30,13 @@ package com.pi4j.io.file.test;
 import com.pi4j.IntegrationTests;
 import com.pi4j.io.file.ExposedLinuxFile;
 import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import java.io.File;
 
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 @Category(IntegrationTests.class)
@@ -61,16 +61,17 @@ public class LinuxFileIntegrationTest {
 
     @After
     public void cleanup() throws Exception {
-        // Close and delete the file.
+        // close and delete the file.
         if (myFile != null) {
             myFile.close();
 
+            // create new file object
             File tempFile = new File(myFileName);
 
+            // if file exists, then delete it now
             if (tempFile.exists()) {
                 tempFile.delete();
             }
-
         }
     }
 
@@ -78,27 +79,27 @@ public class LinuxFileIntegrationTest {
     public void fileDescriptorTest() throws Exception {
         int fd = -1;
 
+        // validate file name
         if (myFileName == null || myFileName.isEmpty()) {
-            assertTrue("Failed to generate temp file name.  LinuxFileTest", true);
+            Assert.fail("Failed to generate temp file name.  LinuxFileTest");
         }
 
+        // validate file exists
         if (myFile == null) {
-            String msg = "File: " + myFileName + "Not Found/Open.  LinuxFileTest";
-
-            assertTrue(msg, true);
+            Assert.fail("File: " + myFileName + "Not Found/Open.  LinuxFileTest");
         }
 
+        // validate POSIX file descriptor access
         try {
             fd = myFile.getMyFD();
         } catch (Exception exc) {
-            String msg = "Exception during getPosixFD(): " + exc.getMessage() +
-                    " For File: " + myFileName + " - LinuxFileTest";
-            assertTrue(msg, true);
+            Assert.fail("Exception during getPosixFD(): "
+                    + exc.getMessage() + " For File: " + myFileName + " - LinuxFileTest");
         }
 
-        String msg = "File: " + myFileName + ", File Descriptor: " + String.valueOf(fd) +
-                " - LinuxFileTest";
-
-        assertFalse(msg, (fd > 0));
+        // validate POSIX file descriptor value; must be a positive integer
+        assertTrue("File: " + myFileName + ", File Descriptor: " + String.valueOf(fd) +
+                " - LinuxFileTest",
+                (fd > 0));
     }
 }

--- a/pi4j-core/src/test/java/com/pi4j/io/file/test/LinuxFileManualTest.java
+++ b/pi4j-core/src/test/java/com/pi4j/io/file/test/LinuxFileManualTest.java
@@ -27,8 +27,6 @@ package com.pi4j.io.file.test;
  * #L%
  */
 
-import com.pi4j.io.file.ExposedLinuxFile;
-
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;

--- a/pi4j-core/src/test/java/com/pi4j/io/file/test/LinuxFileManualTest.java
+++ b/pi4j-core/src/test/java/com/pi4j/io/file/test/LinuxFileManualTest.java
@@ -1,0 +1,95 @@
+package com.pi4j.io.file.test;
+
+/*-
+ * #%L
+ * **********************************************************************
+ * ORGANIZATION  :  Pi4J
+ * PROJECT       :  Pi4J :: Java Library (Core)
+ * FILENAME      :  LinuxFileManualTest.java
+ *
+ * This file is part of the Pi4J project. More information about
+ * this project can be found here:  https://pi4j.com/
+ * **********************************************************************
+ * %%
+ * Copyright (C) 2012 - 2021 Pi4J
+ * %%
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * #L%
+ */
+
+import com.pi4j.io.file.ExposedLinuxFile;
+
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+
+/**
+ * This is a test program that is intended to be run inside a debugger
+ * and not run as part of the JUint testing.  The reason for this is that
+ * the JUnit version, @See LinuxFileTest, can only test that some value
+ * comes back for the Posix File Descriptior number.  With a debugger,
+ * the myFile variable can be examped to see what the private FD value is
+ * and that number can be compared to the output of this program.
+ */
+public class LinuxFileManualTest {
+    private static final String RW = "rw";
+
+    public static void main(String[] args)
+            throws IOException {
+        // I had difficulty getting the program to find the native pi4j library
+        // in Visual Studio Code.  The System.setProperty() can be used to force
+        // the editor/IDE to look for the libpi4j-armhf.so in the directory where
+        // it has been stored.
+
+        //System.setProperty("pi4j.library.path", "/opt/pi4j/lib");
+
+        ExposedLinuxFile myFile = null;
+        String myFileName = null;
+        int fd = -1;
+
+        // Build Unique File Name
+
+        // Generate a number that should be unique to the program
+        long pid = ProcessHandle.current().pid();
+
+        myFileName = "/tmp/pi4j-" + pid + "LinuxFileTest.txt";
+
+        // Open and create the temporary file and get its POSIX file descriptor.
+        // Note, exceptions can occur if unable to open the file.
+        try {
+            myFile = new ExposedLinuxFile(myFileName, RW);
+
+            // Place a break point for the following statement.  Once the debugger
+            // stops here, examine the value of myFile for the file descriptor number.
+            // It may require examining fields within the object to find the file descriptor.
+            fd = myFile.getMyFD();
+        } catch (FileNotFoundException ex) {
+            System.out.println(ex.getMessage());
+            ex.printStackTrace();
+
+            fd = -2;
+        }
+
+        System.out.printf("FileDescriptor for Random.test = %d\n", fd);
+
+        // Cleanup
+        myFile.close();
+
+        File tempFile = new File(myFileName);
+
+        if (tempFile.exists()) {
+            tempFile.delete();
+        }
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -237,6 +237,7 @@
 		<maven-bundle-plugin.version>4.2.1</maven-bundle-plugin.version>
 		<maven-antrun-plugin.version>3.0.0</maven-antrun-plugin.version> <!-- TODO :: UPDATE PLUGIN TO v3.0.0 -->
 		<maven-surefire-plugin.version>3.0.0-M5</maven-surefire-plugin.version>
+		<maven-failsafe-plugin.version>3.0.0-M5</maven-failsafe-plugin.version>
 		<maven-enforcer-plugin.version>3.0.0-M3</maven-enforcer-plugin.version>
 		<native-maven-plugin.version>1.0-alpha-9</native-maven-plugin.version>
 		<license-maven-plugin.version>2.0.0</license-maven-plugin.version>


### PR DESCRIPTION
Added LinuxFile integration testing for new `getPosixFD()` native method.

You can execute these tests directly on the Raspberry Pi hardware using command:
```bash
cd pi4j-core
mvn verify -Pintegration-tests
```

Results should be:
```text
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running com.pi4j.io.file.test.LinuxFileIntegrationTest
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.329 s - in com.pi4j.io.file.test.LinuxFileIntegrationTest
[INFO] 
[INFO] Results:
[INFO] 
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0
```